### PR TITLE
SubjectIterator.h would be rejected by clang

### DIFF
--- a/src/Core/source/SubjectIterator.h
+++ b/src/Core/source/SubjectIterator.h
@@ -484,7 +484,7 @@ while (itrB.hasNext()) {
         private:
             const T* d_current;
             const T* d_root;
-            Observer* d_parent_observer;
+            const Observer* d_parent_observer;
             int d_iterator_id;
         };
     }


### PR DESCRIPTION
- ConstSubjectIterator::d_parent_observer should've been const