### PR TITLE
Switch the "major" macros to use static_cast internally

### DIFF
--- a/src/Core/source/QtilitiesCoreApplication.h
+++ b/src/Core/source/QtilitiesCoreApplication.h
@@ -203,9 +203,9 @@ QSettings settings(QtilitiesCoreApplication::qtilitiesSettingsPath(),QSettings::
     }
 }
 
-#define QtilitiesApp ((Qtilities::Core::QtilitiesCoreApplication *) QCoreApplication::instance())
-#define OBJECT_MANAGER ((Qtilities::Core::QtilitiesCoreApplication *) QCoreApplication::instance())->objectManager()
-#define CONTEXT_MANAGER ((Qtilities::Core::QtilitiesCoreApplication *) QCoreApplication::instance())->contextManager()
-#define TASK_MANAGER ((Qtilities::Core::QtilitiesCoreApplication *) QCoreApplication::instance())->taskManager()
+#define QtilitiesApp static_cast<Qtilities::Core::QtilitiesCoreApplication *>(QCoreApplication::instance())
+#define OBJECT_MANAGER static_cast<Qtilities::Core::QtilitiesCoreApplication *>(QCoreApplication::instance())->objectManager()
+#define CONTEXT_MANAGER static_cast<Qtilities::Core::QtilitiesCoreApplication *>(QCoreApplication::instance())->contextManager()
+#define TASK_MANAGER static_cast<Qtilities::Core::QtilitiesCoreApplication *>(QCoreApplication::instance())->taskManager()
 
 #endif // QTILITIES_CORE_H

--- a/src/CoreGui/source/QtilitiesApplication.h
+++ b/src/CoreGui/source/QtilitiesApplication.h
@@ -251,9 +251,9 @@ QtilitiesApplication::initialize();
 #if defined(QtilitiesApp)
 #undef QtilitiesApp
 #endif
-#define QtilitiesApp ((Qtilities::CoreGui::QtilitiesApplication *) QApplication::instance())
-#define ACTION_MANAGER ((Qtilities::CoreGui::QtilitiesApplication *) QApplication::instance())->actionManager()
-#define CLIPBOARD_MANAGER ((Qtilities::CoreGui::QtilitiesApplication *) QApplication::instance())->clipboardManager()
-#define HELP_MANAGER ((Qtilities::CoreGui::QtilitiesApplication *) QApplication::instance())->helpManager()
+#define QtilitiesApp static_cast<Qtilities::CoreGui::QtilitiesApplication *>(QApplication::instance())
+#define ACTION_MANAGER static_cast<Qtilities::CoreGui::QtilitiesApplication *>(QApplication::instance())->actionManager()
+#define CLIPBOARD_MANAGER static_cast<Qtilities::CoreGui::QtilitiesApplication *>(QApplication::instance())->clipboardManager()
+#define HELP_MANAGER static_cast<Qtilities::CoreGui::QtilitiesApplication *>(QApplication::instance())->helpManager()
 
 #endif // QTILITIES_APPLICATION_H


### PR DESCRIPTION
`static_cast` is a much better thing to use than C-style casts.

Other casts have not been changed because I'm planning a PR that changes all instances of `NULL` and `0` (when used as a pointer) to `nullptr`; most C-style casts are for null pointers in this code base anyway.