### PR TITLE
Mark a bunch of operator[!=<>]='s as const

### DIFF
--- a/src/Core/source/IAvailablePropertyProvider.h
+++ b/src/Core/source/IAvailablePropertyProvider.h
@@ -90,7 +90,7 @@ namespace Qtilities {
 
                 return *this;
             }
-            bool operator==(const PropertySpecification& ref) {
+            bool operator==(const PropertySpecification& ref) const {
                 if (d_displayed_name != ref.d_displayed_name)
                     return false;
                 if (d_property_name != ref.d_property_name)
@@ -116,7 +116,7 @@ namespace Qtilities {
 
                 return true;
             }
-            bool operator!=(const PropertySpecification& ref) {
+            bool operator!=(const PropertySpecification& ref) const {
                 return !(*this==ref);
             }
             /*!

--- a/src/Core/source/InstanceFactoryInfo.h
+++ b/src/Core/source/InstanceFactoryInfo.h
@@ -70,7 +70,7 @@ namespace Qtilities {
             }
             virtual ~InstanceFactoryInfo() {}
 
-            bool operator==(const InstanceFactoryInfo& ref) {
+            bool operator==(const InstanceFactoryInfo& ref) const {
                 if (d_factory_tag != ref.d_factory_tag)
                     return false;
                 if (d_instance_tag != ref.d_instance_tag)
@@ -82,7 +82,7 @@ namespace Qtilities {
 
                 return true;
             }
-            bool operator!=(const InstanceFactoryInfo& ref) {
+            bool operator!=(const InstanceFactoryInfo& ref) const {
                 return !(*this==ref);
             }
             InstanceFactoryInfo& operator=(const InstanceFactoryInfo& ref) {

--- a/src/Core/source/ObjectManager.h
+++ b/src/Core/source/ObjectManager.h
@@ -52,7 +52,7 @@ namespace Qtilities {
 
                 return *this;
             }
-            bool operator==(const SubjectTypeInfo& ref) {
+            bool operator==(const SubjectTypeInfo& ref) const {
                 if (d_meta_type != ref.d_meta_type)
                     return false;
                 if (d_name != ref.d_name)
@@ -60,7 +60,7 @@ namespace Qtilities {
 
                 return true;
             }
-            bool operator!=(const SubjectTypeInfo& ref) {
+            bool operator!=(const SubjectTypeInfo& ref) const {
                 return !(*this==ref);
             }
 
@@ -89,7 +89,7 @@ namespace Qtilities {
 
                 return *this;
             }
-            bool operator==(const PropertyDiffInfo& ref) {
+            bool operator==(const PropertyDiffInfo& ref) const {
                 if (d_added_properties != ref.d_added_properties)
                     return false;
                 if (d_removed_properties != ref.d_removed_properties)
@@ -113,7 +113,7 @@ namespace Qtilities {
                     return true;
                 return false;
             }
-            bool operator!=(const PropertyDiffInfo& ref) {
+            bool operator!=(const PropertyDiffInfo& ref) const {
                 return !(*this==ref);
             }
 

--- a/src/Core/source/ObserverRelationalTable.cpp
+++ b/src/Core/source/ObserverRelationalTable.cpp
@@ -80,7 +80,7 @@ Qtilities::Core::RelationalTableEntry::RelationalTableEntry(const RelationalTabl
     d->obj = other.object();
 }
 
-bool Qtilities::Core::RelationalTableEntry::operator==(const RelationalTableEntry& other) {
+bool Qtilities::Core::RelationalTableEntry::operator==(const RelationalTableEntry& other) const {
     bool equal = true;
     if (equal)
         equal = (d->children == other.children());
@@ -97,7 +97,7 @@ bool Qtilities::Core::RelationalTableEntry::operator==(const RelationalTableEntr
     return equal;
 }
 
-bool Qtilities::Core::RelationalTableEntry::operator!=(const RelationalTableEntry& other) {
+bool Qtilities::Core::RelationalTableEntry::operator!=(const RelationalTableEntry& other) const {
     return !(*this==other);
 }
 
@@ -378,7 +378,7 @@ void Qtilities::Core::ObserverRelationalTable::refresh() {
     constructTable(d->observer);
 }
 
-bool Qtilities::Core::ObserverRelationalTable::compare(ObserverRelationalTable other) {
+bool Qtilities::Core::ObserverRelationalTable::compare(ObserverRelationalTable other) const {
     bool result = true;
 
     // Check for the same amount of items first.

--- a/src/Core/source/ObserverRelationalTable.h
+++ b/src/Core/source/ObserverRelationalTable.h
@@ -43,8 +43,8 @@ namespace Qtilities {
             RelationalTableEntry();
             RelationalTableEntry(int visitorID, int sessionID, const QString& name, int ownership, QObject* obj = 0);
             RelationalTableEntry(const RelationalTableEntry& other);
-            bool operator==(const RelationalTableEntry& other);
-            bool operator!=(const RelationalTableEntry& other);
+            bool operator==(const RelationalTableEntry& other) const;
+            bool operator!=(const RelationalTableEntry& other) const;
 
             //! Get the parents of the entry.
             QList<int> parents() const;
@@ -235,10 +235,10 @@ for (int i = 0; i < table.count(); i++) {
             ObserverRelationalTable();
             ~ObserverRelationalTable();
 
-            bool operator==(const ObserverRelationalTable& other) {
+            bool operator==(const ObserverRelationalTable& other) const {
                 return compare(other);
             }
-            bool operator!=(const ObserverRelationalTable& other) {
+            bool operator!=(const ObserverRelationalTable& other) const {
                 return !compare(other);
             }
 
@@ -253,7 +253,7 @@ for (int i = 0; i < table.count(); i++) {
               entries in the tables must be the same and each entry must be exactly the same (except for d_sessionID and
               d_previousSessionID).
               */
-            bool compare(ObserverRelationalTable table);
+            bool compare(ObserverRelationalTable table) const;
             //! Returns the number of entries in the table.
             int count() const;
             //! Returns the entry with the given visitor ID.

--- a/src/Core/source/QtilitiesProcess.h
+++ b/src/Core/source/QtilitiesProcess.h
@@ -89,7 +89,7 @@ namespace Qtilities {
 
                 return *this;
             }
-            bool operator==(const ProcessBufferMessageTypeHint& ref) {
+            bool operator==(const ProcessBufferMessageTypeHint& ref) const {
                 if (d_message_type != ref.d_message_type)
                     return false;
                 if (d_regexp != ref.d_regexp)
@@ -111,7 +111,7 @@ namespace Qtilities {
 
                 return true;
             }
-            bool operator!=(const ProcessBufferMessageTypeHint& ref) {
+            bool operator!=(const ProcessBufferMessageTypeHint& ref) const {
                 return !(*this==ref);
             }
 

--- a/src/Core/source/VersionInformation.cpp
+++ b/src/Core/source/VersionInformation.cpp
@@ -129,21 +129,21 @@ Qtilities::Core::VersionNumber& Qtilities::Core::VersionNumber::operator=(const 
     return *this;
 }
 
-bool Qtilities::Core::VersionNumber::operator>(const VersionNumber& ref) {
+bool Qtilities::Core::VersionNumber::operator>(const VersionNumber& ref) const {
     if (*this == ref)
         return false;
     else
         return !(*this < ref);
 }
 
-bool Qtilities::Core::VersionNumber::operator>=(const VersionNumber& ref) {
+bool Qtilities::Core::VersionNumber::operator>=(const VersionNumber& ref) const {
     if (*this==ref)
         return true;
     else
         return (*this > ref);
 }
 
-bool Qtilities::Core::VersionNumber::operator<(const VersionNumber& ref) {
+bool Qtilities::Core::VersionNumber::operator<(const VersionNumber& ref) const {
     if (*this == ref)
         return false;
 
@@ -207,7 +207,7 @@ bool Qtilities::Core::VersionNumber::operator<(const VersionNumber& ref) {
     return false;
 }
 
-bool Qtilities::Core::VersionNumber::operator<=(const VersionNumber& ref) {
+bool Qtilities::Core::VersionNumber::operator<=(const VersionNumber& ref) const {
     if (*this==ref)
         return true;
     else

--- a/src/Core/source/VersionInformation.h
+++ b/src/Core/source/VersionInformation.h
@@ -153,22 +153,22 @@ example2_from_string.setIsVersionRevisionUsed(false);
             /*!
              * \note Minor and revision numbers are only considered if both VersionNumbers use them.
              */
-            bool operator>(const VersionNumber& ref);
+            bool operator>(const VersionNumber& ref) const;
             //! Operator overload to check if one VersionNumber to bigger than or equal to another VersionNumber.
             /*!
              * \note Minor and revision numbers are only considered if both VersionNumbers use them.
              */
-            bool operator>=(const VersionNumber& ref);
+            bool operator>=(const VersionNumber& ref) const;
             //! Operator overload to check if one VersionNumber to smaller than another VersionNumber.
             /*!
              * \note Minor and revision numbers are only considered if both VersionNumbers use them.
              */
-            bool operator<(const VersionNumber& ref);
+            bool operator<(const VersionNumber& ref) const;
             //! Operator overload to check if one VersionNumber to smaller than or equal to another VersionNumber.
             /*!
              * \note Minor and revision numbers are only considered if both VersionNumbers use them.
              */
-            bool operator<=(const VersionNumber& ref);
+            bool operator<=(const VersionNumber& ref) const;
 
             //! Is null means the version is 0.0.0, this will be the case when object is constructed with default constructor.
             bool isNull() const;

--- a/src/Logging/source/AbstractFormattingEngine.h
+++ b/src/Logging/source/AbstractFormattingEngine.h
@@ -48,7 +48,7 @@ namespace Qtilities {
 
                 return *this;
             }
-            bool operator==(const CustomFormattingHint& ref) {
+            bool operator==(const CustomFormattingHint& ref) const {
                 if (d_hint != ref.d_hint)
                     return false;
                 if (d_message_type_flags != ref.d_message_type_flags)
@@ -58,7 +58,7 @@ namespace Qtilities {
 
                 return true;
             }
-            bool operator!=(const CustomFormattingHint& ref) {
+            bool operator!=(const CustomFormattingHint& ref) const {
                 return !(*this==ref);
             }
 


### PR DESCRIPTION
And a member function.

This allows the relevant classes to be compared despite being `const`.  Subtle little bug.