### PR TITLE
Change all uses of Q_(ENUM|FLAG)S to just Q_(ENUM|FLAG)

### DIFF
--- a/src/Core/source/AbstractSubjectFilter.h
+++ b/src/Core/source/AbstractSubjectFilter.h
@@ -43,7 +43,6 @@ namespace Qtilities {
         class QTILIITES_CORE_SHARED_EXPORT AbstractSubjectFilter : public QObject, virtual public IExportable
         {
             Q_OBJECT
-            Q_ENUMS(EvaluationResult)
 
             friend class Observer;
 
@@ -63,6 +62,7 @@ namespace Qtilities {
                 Conditional,    /*!< Validation is conditional. %Examples of this is when the user still needs to decide how to rename an object, thus it is not possible to know before hand what the result will be. */
                 Rejected        /*!< Validation failed. */
             };
+            Q_ENUM(EvaluationResult)
 
             //! Returns the name of the subject filter.
             virtual QString filterName() const = 0;

--- a/src/Core/source/ActivityPolicyFilter.h
+++ b/src/Core/source/ActivityPolicyFilter.h
@@ -51,9 +51,6 @@ ActivityPolicyFilter* activity_filter = tree_node->enableActivityControl(Observe
         {
             Q_OBJECT
             Q_INTERFACES(Qtilities::Core::Interfaces::IModificationNotifier)
-            Q_ENUMS(ActivityPolicy)
-            Q_ENUMS(MinimumActivityPolicy)
-            Q_ENUMS(NewSubjectActivityPolicy)
 
         public:
             ActivityPolicyFilter(QObject* parent = 0);
@@ -98,6 +95,8 @@ ActivityPolicyFilter* activity_filter = tree_node->enableActivityControl(Observe
                 UniqueActivity,     /*!< Only one subject can be active at any time. */
                 MultipleActivity    /*!< Multiple subjects can be active at any time. */
             };
+            Q_ENUM(ActivityPolicy)
+
             //! Function which returns a string associated with a specific ActivityPolicy.
             static QString activityPolicyToString(ActivityPolicy activity_policy);
             //! Function which returns the ActivityPolicy associated with a string.
@@ -129,6 +128,8 @@ ActivityPolicyFilter* activity_filter = tree_node->enableActivityControl(Observe
                 ParentIgnoreActivity,     /*!< This filter does not track or care about the activity of its observer parent. */
                 ParentFollowActivity      /*!< This filter tracks the activity of its observer parent. */
             };
+            Q_ENUM(ParentTrackingPolicy)
+
             //! Function which returns a string associated with a specific ParentTrackingPolicy.
             static QString parentTrackingPolicyToString(ParentTrackingPolicy parent_tracking_policy);
             //! Function which returns the ParentTrackingPolicy associated with a string.
@@ -141,6 +142,8 @@ ActivityPolicyFilter* activity_filter = tree_node->enableActivityControl(Observe
                 AllowNoneActive,    /*!< All subjects can be incative at the same time. */
                 ProhibitNoneActive  /*!< There should at least be one active subject at any time, unless no subjects are attached to the observer context in which the filter is installed */
             };
+            Q_ENUM(MinimumActivityPolicy)
+
             //! Function which returns a string associated with a specific MinimumActivityPolicy.
             static QString minimumActivityPolicyToString(MinimumActivityPolicy minimum_activity_policy);
             //! Function which returns the MinimumActivityPolicy associated with a string.
@@ -153,6 +156,8 @@ ActivityPolicyFilter* activity_filter = tree_node->enableActivityControl(Observe
                 SetNewActive,       /*!< New subjects are automatically set to be active. */
                 SetNewInactive      /*!< New subjects are automatically set to be inactive. */
             };
+            Q_ENUM(NewSubjectActivityPolicy)
+
             //! Function which returns a string associated with a specific NewSubjectActivityPolicy.
             static QString newSubjectActivityPolicyToString(NewSubjectActivityPolicy new_subject_activity_policy);
             //! Function which returns the NewSubjectActivityPolicy associated with a string.

--- a/src/Core/source/FileUtils.h
+++ b/src/Core/source/FileUtils.h
@@ -40,13 +40,14 @@ namespace Qtilities {
         class QTILIITES_CORE_SHARED_EXPORT FileUtils : public QObject, public ITaskContainer {
             Q_OBJECT
             Q_INTERFACES(Qtilities::Core::Interfaces::ITaskContainer)
-            Q_ENUMS(ContainedTasks)
 
         public:
             //! Access names for tasks provided by FileUtils.
             enum ContainedTasks {
                 TaskFindFilesUnderDir   = 0  /*!< The task which allows monitoring of the findFilesUnderDir() function's progress. */
             };
+            Q_ENUM(ContainedTasks)
+
             //! ContainedTasks to string conversion function.
             QString taskNameToString(ContainedTasks task_name) const {
                 if (task_name == TaskFindFilesUnderDir)

--- a/src/Core/source/GenericProperty.h
+++ b/src/Core/source/GenericProperty.h
@@ -112,13 +112,16 @@ namespace Qtilities {
                 TypeDouble = 512,
                 TypeListBased = TypeFileList | TypePathList
             };
-            Q_ENUMS(PropertyType)
+            Q_DECLARE_FLAGS(PropertyTypeFlag, PropertyType)
+            Q_FLAG(PropertyTypeFlag)
+
             //! Possible property levels.
             enum PropertyLevel {
                 LevelStandard = 0,
                 LevelAdvanced = 1
             };
-            Q_ENUMS(PropertyLevel)
+            Q_ENUM(PropertyLevel)
+
             //! Macro mode of this property.
             /*!
               Default is MacroUnexpanded.
@@ -132,7 +135,9 @@ namespace Qtilities {
                 MacroExpandedAll = MacroExpanded | MacroExpandedCustom,
                 MacrosAll = MacroExpandedAll | MacroUnexpanded
             };
-            Q_ENUMS(MacroMode)
+            Q_DECLARE_FLAGS(MacroModeFlag, MacroMode)
+            Q_FLAG(MacroModeFlag)
+
 
             static QString propertyTypeToString(PropertyType property_type) {
                 if (property_type == TypeInteger) {
@@ -240,7 +245,8 @@ namespace Qtilities {
             enum FileListStringFormat {
                 FileListStringFormat_0 = 0      /*!< Files are returned in this format (it does not care if there are spaces in the files): {"file_path_1" "file_path_2"} */
             };
-            Q_ENUMS(FileListStringFormat)
+            Q_ENUM(FileListStringFormat)
+
 
             explicit GenericProperty(QObject *parent = 0);
             explicit GenericProperty(const QString& property_name, QObject *parent = 0);
@@ -615,6 +621,9 @@ namespace Qtilities {
 
             GenericPropertyData* d;
         };
+
+        Q_DECLARE_OPERATORS_FOR_FLAGS(GenericProperty::PropertyTypeFlag)
+        Q_DECLARE_OPERATORS_FOR_FLAGS(GenericProperty::MacroModeFlag)
     }
 }
 

--- a/src/Core/source/IExportable.h
+++ b/src/Core/source/IExportable.h
@@ -264,6 +264,8 @@ int main(int argc, char *argv[])
 
               */
             class QTILIITES_CORE_SHARED_EXPORT IExportable : virtual public IObjectBase {
+                Q_GADGET
+
             public:
                 IExportable();
                 virtual ~IExportable() {}
@@ -278,8 +280,7 @@ int main(int argc, char *argv[])
                     XML = 2        /*!< XML exporting using QDomDocument. \sa exportXml(), importXml() */
                 };
                 Q_DECLARE_FLAGS(ExportModeFlags, ExportMode)
-                Q_FLAGS(ExportModeFlags)
-                Q_ENUMS(ExportMode)
+                Q_FLAG(ExportModeFlags)
 
                 //! The possible results of an export/import operation.
                 enum Result {
@@ -294,8 +295,8 @@ int main(int argc, char *argv[])
                     FailedResult = Failed | FailedContinue | VersionTooNew | VersionTooOld  /*!< Failed operation. */
                 };
                 Q_DECLARE_FLAGS(ExportResultFlags, Result)
-                Q_FLAGS(ExportResultFlags)
-                Q_ENUMS(Result)
+                Q_FLAG(ExportResultFlags)
+
 
                 //! Provides information about the export format(s) supported by your implementation of IExportable.
                 /*!

--- a/src/Core/source/IModificationNotifier.h
+++ b/src/Core/source/IModificationNotifier.h
@@ -38,6 +38,8 @@ namespace Qtilities {
             returned by objectBase().
               */
             class QTILIITES_CORE_SHARED_EXPORT IModificationNotifier : virtual public IObjectBase {
+                Q_GADGET
+
             public:
                 IModificationNotifier() : d_isModified(false) {}
                 virtual ~IModificationNotifier() {}

--- a/src/Core/source/IModificationNotifier.h
+++ b/src/Core/source/IModificationNotifier.h
@@ -51,7 +51,7 @@ namespace Qtilities {
                     NotifySubjects  = 2   /*!< Notify all subjects about the new state. The new state will be set on all subjects as well. */
                 };
                 Q_DECLARE_FLAGS(NotificationTargets, NotificationTarget)
-                Q_FLAGS(NotificationTargets)
+                Q_FLAG(NotificationTargets)
 
                 //! Indicates the modification state of the object.
                 virtual bool isModified() const = 0;

--- a/src/Core/source/IObjectManager.h
+++ b/src/Core/source/IObjectManager.h
@@ -48,7 +48,7 @@ namespace Qtilities {
                     AllPropertyTypes = MultiContextProperties | SharedProperties | QtilitiesInternalProperties | NonQtilitiesProperties
                 };
                 Q_DECLARE_FLAGS(PropertyTypeFlags, PropertyTypes)
-                Q_FLAGS(PropertyTypeFlags)
+                Q_FLAG(PropertyTypeFlags)
 
                 IObjectManager(QObject* parent = 0) : QObject(parent) {}
                 virtual ~IObjectManager() {}

--- a/src/Core/source/Observer.h
+++ b/src/Core/source/Observer.h
@@ -120,10 +120,6 @@ observerWidget.show();
             Q_INTERFACES(Qtilities::Core::Interfaces::IExportable)
             Q_INTERFACES(Qtilities::Core::Interfaces::IExportableObserver)
             Q_INTERFACES(Qtilities::Core::Interfaces::IModificationNotifier)
-            Q_ENUMS(SubjectChangeIndication)
-            Q_ENUMS(ObjectOwnership)
-            Q_ENUMS(EvaluationResult)
-            Q_ENUMS(AccessMode)
 
             Q_PROPERTY(QString Name READ observerName)
             Q_PROPERTY(QString Description READ observerDescription)
@@ -149,6 +145,8 @@ observerWidget.show();
                 IsParentObserver,           /*!< Only used during detachment. Indicates that the observer is the parent of the object. This result takes priority over the other possible results. The use case is where the Object Manager attempts to move objects between observers. When attempting to move objects between two observers it will not move subjects which returns this during their detachment validation. */
                 LastScopedObserver          /*!< Only used during detachment. Indicates that the observer is the last scoped parent of the object. This result takes priority over the other possible results except IsParentObserver. The use case is where the Object Manager attempts to move objects between observers. When attempting to move objects between two observers it will not move subjects which returns this during their detachment validation. */
             };
+            Q_ENUM(EvaluationResult)
+
             //! The possible indications that can be returned when the number of subjects in the observer changes.
             /*!
               \sa numberOfSubjectsChanged()
@@ -158,6 +156,8 @@ observerWidget.show();
                 SubjectRemoved,             /*!< Indicates that subjects were removed. */
                 CyclicProcess               /*!< Indicates that the number of subjects changed during a cyclic process. The subject count can either be less or more than before the cyclic operation. \sa startProcessingCycle(), endProcessingCycle() */
             };
+            Q_ENUM(SubjectChangeIndication)
+
             //! The possible ownerships with which subjects can be attached to an observer.
             /*!
               See the \ref object_lifetimes section of the \ref page_observers article for a detailed discussion.
@@ -358,6 +358,8 @@ In this example \p observerA will be deleted as soon as \p object1 is deleted.
 \note QWidget's parent must be another QWidget, thus these rules don't apply to QWidgets.
                 */
             };
+            Q_ENUM(ObjectOwnership)
+
             //! Function which returns a string associated with a specific ObjectOwnership.
             static QString objectOwnershipToString(ObjectOwnership ownership);
             //! Function which returns the ObjectOwnership associated with a string.
@@ -372,6 +374,8 @@ In this example \p observerA will be deleted as soon as \p object1 is deleted.
                 LockedAccess = 2,           /*!< The observer is read only and locked. Item views presenting this observer to the user will respect the LockedAccess mode and will not display the contents of the observer to the user. */
                 InvalidAccess = 3           /*!< An invalid access mode. This access mode is returned in functions where the access mode is requested for a category that does not exist, for example categoryAccessMode(). */
             };
+            Q_ENUM(AccessMode)
+
             //! Function which returns a string associated with a specific AccessMode.
             static QString accessModeToString(AccessMode access_mode);
             //! Function which returns the AccessMode associated with a string.
@@ -386,6 +390,8 @@ In this example \p observerA will be deleted as soon as \p object1 is deleted.
                 DeleteImmediately = 0,     /*!< When subjects are deleted by this observer, the normal \p delete operator is used. */
                 DeleteLater = 1            /*!< When subjects are deleted by this observer, deleteLater() are called on them. */
             };
+            Q_ENUM(ObjectDeletionPolicy)
+
             //! Function which returns a string associated with a specific ObjectDeletionPolicy.
             static QString objectDeletionPolicyToString(ObjectDeletionPolicy object_deletion_policy);
             //! Function which returns the ObjectDeletionPolicy associated with a string.
@@ -399,6 +405,8 @@ In this example \p observerA will be deleted as soon as \p object1 is deleted.
                 GlobalScope = 0,            /*!< The global access mode is used for all categories when categories are used. */
                 CategorizedScope = 1        /*!< Access modes are category specific. */
             };
+            Q_ENUM(AccessModeScope)
+
             //! Function which returns a string associated with a specific AccessModeScope.
             static QString accessModeScopeToString(AccessModeScope access_mode_scope);
             //! Function which returns the AccessModeScope associated with a string.

--- a/src/Core/source/ObserverData.h
+++ b/src/Core/source/ObserverData.h
@@ -56,7 +56,7 @@ namespace Qtilities {
                 ExportAllItems             = ExportData | ExportVisitorIDs | ExportRelationalData
             };
             Q_DECLARE_FLAGS(ExportItemFlags, ExportItem)
-            Q_FLAGS(ExportItemFlags)
+            Q_FLAG(ExportItemFlags)
 
             ObserverData(Observer* obs, const QString& observer_name) : IObjectBase(), IExportable(), subject_limit(-1),
                 subject_id_counter(0),

--- a/src/Core/source/ObserverData.h
+++ b/src/Core/source/ObserverData.h
@@ -42,6 +42,8 @@ namespace Qtilities {
           */
         class QTILIITES_CORE_SHARED_EXPORT ObserverData : public IExportable
         {
+            Q_GADGET
+
         public:
             //! The possible export flags used during extended observer exports.
             /*!

--- a/src/Core/source/ObserverDotWriter.h
+++ b/src/Core/source/ObserverDotWriter.h
@@ -245,7 +245,6 @@ digraph "Root Node" {
         class QTILIITES_CORE_SHARED_EXPORT ObserverDotWriter : public QObject
         {
             Q_OBJECT
-            Q_ENUMS(GraphType)
 
         public:
             //! Default constructor

--- a/src/Core/source/ObserverHints.h
+++ b/src/Core/source/ObserverHints.h
@@ -51,17 +51,6 @@ namespace Qtilities {
             Q_OBJECT
             Q_INTERFACES(Qtilities::Core::Interfaces::IModificationNotifier)
             Q_INTERFACES(Qtilities::Core::Interfaces::IExportable)
-            Q_ENUMS(DisplayFlag)
-            Q_ENUMS(NamingControl)
-            Q_ENUMS(ActivityDisplay)
-            Q_ENUMS(ActivityControl)
-            Q_ENUMS(ItemSelectionControl)
-            Q_ENUMS(HierarchicalDisplay)
-            Q_ENUMS(ItemViewColumn)
-            Q_ENUMS(DragDropHint)
-            Q_ENUMS(ModificationStateDisplayHint)
-            Q_ENUMS(CategoryEditingHint)
-            Q_ENUMS(RootIndexDisplayHint)
 
         public:
             // --------------------------------
@@ -96,6 +85,8 @@ namespace Qtilities {
                 SelectionUseSelectedContext = 2         /*!< Use the selected observer's context. Only enforced when a single selection is present in an ObserverWidget tree. When more items are selected
                                                              SelectionUseParentContext will be used */
             };
+            Q_ENUM(ObserverSelectionContext)
+
             //! Function which returns a string associated with a specific ObserverSelectionContext.
             static QString observerSelectionContextToString(ObserverSelectionContext observer_selection_context);
             //! Function which returns the ObserverSelectionContext associated with a string.
@@ -109,6 +100,8 @@ namespace Qtilities {
                 ReadOnlyNames = 1,          /*!< Names cannot be edited in item views viewing this observer. */
                 EditableNames = 2           /*!< Names are editable in item views viewing this observer. */
             };
+            Q_ENUM(NamingControl)
+
             //! Function which returns a string associated with a specific NamingControl.
             static QString namingControlToString(NamingControl naming_control);
             //! Function which returns the NamingControl associated with a string.
@@ -122,6 +115,8 @@ namespace Qtilities {
                 NoActivityDisplay = 1,      /*!< The activity of items are not displayed in item views viewing this observer. */
                 CheckboxActivityDisplay = 2 /*!< If the observer has an ActivityPolicyFilter subject filter installed, a check box which shows the activity of subjects are shown in item views viewing this observer. */
             };
+            Q_ENUM(ActivityDisplay)
+
             //! Function which returns a string associated with a specific ActivityDisplay.
             static QString activityDisplayToString(ActivityDisplay activity_display);
             //! Function which returns the ActivityDisplay associated with a string.
@@ -136,6 +131,8 @@ namespace Qtilities {
                 FollowSelection = 2,        /*!< The activity of subjects follows the selection of the user in item views viewing this observer. To use this option, ItemSelectionControl must be set to SelectableItems. */
                 CheckboxTriggered = 3       /*!< The activity of subjects can be changed by checking or unchecking the checkbox appearing next to subject in item views viewing this observer. To use this option, ActivityDisplay must be set to CheckboxActivityDisplay. */
             };
+            Q_ENUM(ActivityControl)
+
             //! Function which returns a string associated with a specific ActivityControl.
             static QString activityControlToString(ActivityControl activity_control);
             //! Function which returns the ActivityControl associated with a string.
@@ -149,6 +146,8 @@ namespace Qtilities {
                 SelectableItems = 1,            /*!< Items are selectable by the user in item views viewing this observer. */
                 NonSelectableItems = 2          /*!< Items are not selectable by the user in item views viewing this observer. */
             };
+            Q_ENUM(ItemSelectionControl)
+
             //! Function which returns a string associated with a specific ItemSelectionControl.
             static QString itemSelectionControlToString(ItemSelectionControl item_selection_control);
             //! Function which returns the ItemSelectionControl associated with a string.
@@ -162,6 +161,8 @@ namespace Qtilities {
                 FlatHierarchy = 1,              /*!< The hierarchy of items under an observer is flat. Thus categories are not displayed. */
                 CategorizedHierarchy = 2        /*!< Item are grouped by their category */
             };
+            Q_ENUM(HierarchicalDisplay)
+
             //! Function which returns a string associated with a specific HierarchicalDisplay.
             static QString hierarchicalDisplayToString(HierarchicalDisplay hierarchical_display);
             //! Function which returns the HierarchicalDisplay associated with a string.
@@ -181,7 +182,7 @@ namespace Qtilities {
                 ColumnAllHints = ColumnNameHint | ColumnChildCountHint | ColumnTypeInfoHint | ColumnAccessHint | ColumnCategoryHint /*!< All columns, except ColumnIDHint. */
             };
             Q_DECLARE_FLAGS(ItemViewColumnFlags, ItemViewColumn)
-            Q_FLAGS(ItemViewColumnFlags)
+            Q_FLAG(ItemViewColumnFlags)
             //! Function which returns a string associated with a specific ItemViewColumnFlags.
             static QString itemViewColumnFlagsToString(ItemViewColumnFlags item_view_column_flags);
             //! Function which returns the ItemViewColumnFlags associated with a string.
@@ -200,7 +201,8 @@ namespace Qtilities {
                 AllDisplayFlagHint = ItemView | NavigationBar | PropertyBrowser | ActionToolBar | DynamicPropertyBrowser
             };
             Q_DECLARE_FLAGS(DisplayFlags, DisplayFlag)
-            Q_FLAGS(DisplayFlags)
+            Q_FLAG(DisplayFlags)
+
             //! Function which returns a string associated with a specific DisplayFlags.
             static QString displayFlagsToString(DisplayFlags display_flags);
             //! Function which returns the DisplayFlags associated with a string.
@@ -229,7 +231,8 @@ namespace Qtilities {
                 ActionAllHints = ActionRemoveItem | ActionRemoveAll | ActionDeleteItem | ActionDeleteAll | ActionNewItem | ActionRefreshView | ActionPushUp | ActionPushUpNew | ActionPushDown | ActionPushDownNew | ActionSwitchView | ActionCopyItem | ActionCutItem | ActionPasteItem | ActionFindItem /*!< All actions. */
             };
             Q_DECLARE_FLAGS(ActionHints, ActionItem)
-            Q_FLAGS(ActionHints)
+            Q_FLAG(ActionHints)
+
             //! Function which returns a string associated with a specific ActionHints.
             static QString actionHintsToString(ActionHints actions_hints);
             //! Function which returns the ActionHints associated with a string.
@@ -249,7 +252,8 @@ namespace Qtilities {
                 AllDragDrop = AcceptDrops | AllowDrags
             };
             Q_DECLARE_FLAGS(DragDropFlags, DragDropHint)
-            Q_FLAGS(DragDropFlags)
+            Q_FLAG(DragDropFlags)
+
             //! Function which returns a string associated with a specific DragDropFlags.
             static QString dragDropFlagsToString(DragDropFlags drag_drop_flags);
             //! Function which returns the DragDropFlags associated with a string.
@@ -262,6 +266,8 @@ namespace Qtilities {
                 NoModificationStateDisplayHint = 0,         /*!< No modification state display hint. The modification state is not displayed in any way. */
                 CharacterModificationStateDisplay = 1       /*!< The modification state of items is displayed by appending a specific character "*" to names of modified items. */
             };
+            Q_ENUM(ModificationStateDisplayHint)
+
             //! Function which returns a string associated with a specific ModificationStateDisplayHint.
             static QString modificationStateDisplayToString(ModificationStateDisplayHint modification_display);
             //! Function which returns the ModificationStateDisplayHint associated with a string.
@@ -289,7 +295,8 @@ node->displayHints()->setDragDropHint(ObserverHints::AllowDrags);
                 CategoriesAcceptSubjectDrops = 8    /*!< Categories accept subject(s) dropped onto them and assigns the dropped category to the subject(s). */
             };
             Q_DECLARE_FLAGS(CategoryEditingFlags, CategoryEditingHint)
-            Q_FLAGS(CategoryEditingFlags)
+            Q_FLAG(CategoryEditingFlags)
+
             //! Function which returns a string associated with a specific CategoryEditingFlags.
             static QString categoryEditingFlagsToString(CategoryEditingFlags category_editing_flags);
             //! Function which returns the CategoryEditingFlags associated with a string.
@@ -310,6 +317,8 @@ node->displayHints()->setDragDropHint(ObserverHints::AllowDrags);
                 RootIndexDisplayUndecorated  = 2 /*!< Display the root index but don't decorate it. See QTreeView::rootIsDecorated() for more details on decoration. An example tree displayed using this hint can be seen below: \image html observer_hints_root_index_display_undecorated.jpg "Tree Displayed Using RootIndexDisplayUndecorated" */
 
             };
+            Q_ENUM(RootIndexDisplayHint)
+
             //! Function which returns a string associated with a specific RootIndexDisplayHint.
             /*!
               *<i>This function was added in %Qtilities v1.2.</i>

--- a/src/Core/source/Task.h
+++ b/src/Core/source/Task.h
@@ -43,13 +43,6 @@ namespace Qtilities {
             Q_OBJECT
             Q_INTERFACES(Qtilities::Core::Interfaces::ITask)
 
-//            Q_ENUMS(ITask::TaskState)
-//            Q_ENUMS(ITask::TaskResult)
-//            Q_ENUMS(ITask::TaskType)
-//            Q_ENUMS(ITask::TaskStopAction)
-//            Q_ENUMS(ITask::TaskRemoveAction)
-//            Q_ENUMS(ITask::TaskState)
-
             // Add properties to task to simplify debugging in Qtilities Debug widget:
             Q_PROPERTY(QString Name READ taskName)
             Q_PROPERTY(QString DisplayName READ displayName)
@@ -80,8 +73,8 @@ namespace Qtilities {
                 LifeTimeDestroyWhenCompleted                = LifeTimeDestroyWhenSuccessful | LifeTimeDestroyWhenSuccessfullWithWarnings | LifeTimeDestroyWhenStopped | LifeTimeDestroyWhenFailed  /*!< The task will destroy itself when completed, independent of the state if completed in. */
             };
             Q_DECLARE_FLAGS(TaskLifeTimeFlags, TaskLifeTime)
-            Q_FLAGS(TaskLifeTimeFlags)
-            Q_ENUMS(TaskLifeTime)
+            Q_FLAG(TaskLifeTimeFlags)
+
 
             //! Default constructor
             /*!

--- a/src/Core/source/Zipper.h
+++ b/src/Core/source/Zipper.h
@@ -78,7 +78,6 @@ and http://sevenzip.sourceforge.jp/chm/cmdline/commands/
 class QTILIITES_CORE_SHARED_EXPORT Zipper : public QObject
 {
     Q_OBJECT
-    Q_ENUMS(ZipMode)
 
 public:
     /*!
@@ -126,6 +125,8 @@ public:
         CopyMode = 0,       /*!< Only do a copy, uses the -mx0 switch. */
         CompressMode = 1    /*!< Does a compression, uses the default settings. */
     };
+    Q_ENUM(ZipMode)
+
     //! Convenience function to zip a folder to a file.
     /*!
      * It is possible to control whether the filenames in the archive will contain the folder_path prefix. For example:

--- a/src/CoreGui/source/AddDynamicPropertyWizard.h
+++ b/src/CoreGui/source/AddDynamicPropertyWizard.h
@@ -50,7 +50,7 @@ namespace Qtilities {
                 ConstructDoNotAdd      = 1 << 2  /*!< Constructs the property, but don't add it to the property to the object set using
                                                       setObject(). Instead, the constructed property can be obtained through constructedProperty(). */
             };
-            Q_ENUMS(PropertyCreationHint)
+            Q_ENUM(PropertyCreationHint)
 
             explicit AddDynamicPropertyWizard(PropertyCreationHint property_creation_hint = ConstructAndAdd, QWidget *parent = 0);
             virtual ~AddDynamicPropertyWizard();

--- a/src/CoreGui/source/CodeEditorWidget.h
+++ b/src/CoreGui/source/CodeEditorWidget.h
@@ -118,7 +118,7 @@ code_editor.codeEditor()->setReadOnly(true);
                 ActionAllHints = ActionNoHints | ActionOpenFile | ActionSaveFile | ActionSaveFileAs | ActionPrint | ActionPrintPreview | ActionPrintPDF | ActionUndo | ActionRedo | ActionCut | ActionCopy | ActionPaste |ActionClear | ActionSelectAll | ActionFind
             };
             Q_DECLARE_FLAGS(ActionFlags, ActionFlag)
-            Q_FLAGS(ActionFlags)
+            Q_FLAG(ActionFlags)
             //! The possible display flags of the code editor widget.
             /*!
               \sa displayFlagsHint()
@@ -131,7 +131,7 @@ code_editor.codeEditor()->setReadOnly(true);
                 AllDisplayFlagHint = Editor | SearchBox | ActionToolBar
             };
             Q_DECLARE_FLAGS(DisplayFlags, DisplayFlag)
-            Q_FLAGS(DisplayFlags)
+            Q_FLAG(DisplayFlags)
 
             //! Defines how the editor should handle a situation where the open file is removed outside of the editor.
             enum FileRemovedOutsideHandlingPolicy {

--- a/src/CoreGui/source/GenericPropertyBrowser.h
+++ b/src/CoreGui/source/GenericPropertyBrowser.h
@@ -35,7 +35,6 @@ namespace Qtilities {
         class QTILITIES_CORE_GUI_SHARED_EXPORT GenericPropertyBrowser : public QMainWindow
         {
             Q_OBJECT
-            Q_ENUMS(BrowserType)
 
         public:
             //! This enumeration contains all the possible modes in which the property editor can be used.
@@ -44,6 +43,7 @@ namespace Qtilities {
                 GroupBoxBrowser,
                 ButtonBrowser
             };
+            Q_ENUM(BrowserType)
 
             GenericPropertyBrowser(GenericPropertyManager* property_manager, BrowserType browser_type = TreeBrowser, QWidget *parent = 0);
             ~GenericPropertyBrowser();

--- a/src/CoreGui/source/IActionProvider.h
+++ b/src/CoreGui/source/IActionProvider.h
@@ -50,8 +50,8 @@ namespace Qtilities {
                     FilterDisabled = 1,     /*!< Filter disabled actions, thus only enabled actions will be returned. */
                     FilterHidden = 2        /*!< Filter hidden actions, thus only visible actions will be returned. */
                 };
-                Q_DECLARE_FLAGS(ActionFilterFlags, ActionFilter);
-                Q_FLAGS(ActionFilterFlags);
+                Q_DECLARE_FLAGS(ActionFilterFlags, ActionFilter)
+                Q_FLAG(ActionFilterFlags)
 
                 //! A list of all the actions provided through the interface.
                 /*!

--- a/src/CoreGui/source/IActionProvider.h
+++ b/src/CoreGui/source/IActionProvider.h
@@ -35,6 +35,8 @@ namespace Qtilities {
             For more information see ActionProvider.
               */
             class QTILITIES_CORE_GUI_SHARED_EXPORT IActionProvider : virtual public IObjectBase {
+                Q_GADGET
+
             public:
                 IActionProvider() {}
                 virtual ~IActionProvider() {}

--- a/src/CoreGui/source/IClipboard.h
+++ b/src/CoreGui/source/IClipboard.h
@@ -107,7 +107,6 @@ if (observer_mime_data) {
             class QTILITIES_CORE_GUI_SHARED_EXPORT IClipboard : public QObject, virtual public IObjectBase
             {
                 Q_OBJECT
-                Q_ENUMS(ClipboardOrigin)
 
             public:
                 IClipboard(QObject* parent = 0) : QObject(parent) {}
@@ -122,6 +121,7 @@ if (observer_mime_data) {
                     CutAction,          /*!< A cut action changed the clipboard. */
                     Unspecified         /*!< An unspecified action changed the clipboard. */
                 };
+                Q_ENUM(ClipboardOrigin)
 
                 //! Gives information about the data which was placed in the clipboard.
                 virtual ClipboardOrigin clipboardOrigin() = 0;

--- a/src/CoreGui/source/LoggerEnginesTableModel.h
+++ b/src/CoreGui/source/LoggerEnginesTableModel.h
@@ -26,7 +26,6 @@ namespace Qtilities {
         class qti_private_LoggerEnginesTableModel : public QAbstractTableModel
         {
             Q_OBJECT
-            Q_ENUMS(ColumnIDs)
 
         public:
             qti_private_LoggerEnginesTableModel(QObject* parent = 0);
@@ -35,6 +34,7 @@ namespace Qtilities {
             enum ColumnIDs {
                 NameColumn = 0
             };
+            Q_ENUM(ColumnIDs)
 
             virtual Qt::ItemFlags flags(const QModelIndex &index) const;
             virtual QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;

--- a/src/CoreGui/source/NamingPolicyFilter.h
+++ b/src/CoreGui/source/NamingPolicyFilter.h
@@ -127,9 +127,6 @@ if (ObjectManager::propertyExists(obj,qti_prop_NAME)) {
         {
             Q_OBJECT
             Q_INTERFACES(Qtilities::Core::Interfaces::IModificationNotifier)
-            Q_ENUMS(UniquenessPolicy)
-            Q_ENUMS(ResolutionPolicy)
-            Q_ENUMS(ValidityCheckResult)
 
             friend class NamingPolicyInputDialog;
 
@@ -156,6 +153,8 @@ if (ObjectManager::propertyExists(obj,qti_prop_NAME)) {
                 ProhibitDuplicateNames,                 /*!< Prohibit duplicate names (checking for duplicate names done in a case in-sensitive way). */
                 ProhibitDuplicateNamesCaseSensitive     /*!< Prohibit duplicate names (checking for duplicate names done in a case sensitive way). */
             };
+            Q_ENUM(UniquenessPolicy)
+
             //! Function which returns a string associated with a specific UniquenessPolicy.
             static QString uniquenessPolicyToString(UniquenessPolicy uniqueness_policy);
             //! Function which returns the UniquenessPolicy associated with a string.
@@ -170,6 +169,8 @@ if (ObjectManager::propertyExists(obj,qti_prop_NAME)) {
                 Replace = 2,                /*!< Replace the conflicting object with the current object. This option will only work when the conflicting object is only observed in the context to which the naming policy filter is attached. If this is the case, the replacement operation will delete the conflicting object and attach the new object to the observer. \note The Replace policy is only usable when duplicate names are encountered, not invalid names. For invalid names Reject will be used. */
                 Reject = 3                  /*!< Reject unacceptable names.*/
             };
+            Q_ENUM(ResolutionPolicy)
+
             //! Function which returns a string associated with a specific ResolutionPolicy.
             static QString resolutionPolicyToString(ResolutionPolicy resolution_policy);
             //! Function which returns the ResolutionPolicy associated with a string.
@@ -185,7 +186,8 @@ if (ObjectManager::propertyExists(obj,qti_prop_NAME)) {
                 AllChecks = Validity | Uniqueness /*!< All checks are performed. */
             };
             Q_DECLARE_FLAGS(ValidationCheckFlags, ValidationCheck)
-            Q_FLAGS(ValidationCheckFlags)
+            Q_FLAG(ValidationCheckFlags)
+
             //! Function which returns a string associated with a specific ValidationCheckFlags.
             static QString validationCheckFlagsToString(ValidationCheckFlags validation_checks);
             //! Function which returns the ValidationCheckFlags associated with a string.
@@ -200,7 +202,7 @@ if (ObjectManager::propertyExists(obj,qti_prop_NAME)) {
                 Invalid = 2             /*!< The name is invalid in this context. \sa setValidator(), getValidator(). */
             };
             Q_DECLARE_FLAGS(NameValidity, ValidityCheckResult)
-            Q_FLAGS(NameValidity)
+            Q_FLAG(NameValidity)
 
             // --------------------------------
             // Factory Interface Implementation

--- a/src/CoreGui/source/ObjectDynamicPropertyBrowser.h
+++ b/src/CoreGui/source/ObjectDynamicPropertyBrowser.h
@@ -60,7 +60,6 @@ namespace Qtilities {
         class QTILITIES_CORE_GUI_SHARED_EXPORT ObjectDynamicPropertyBrowser : public QMainWindow
         {
             Q_OBJECT          
-            Q_ENUMS(BrowserType)
 
         public:
             //! This enumeration contains all the possible modes in which the property editor can be used.
@@ -78,6 +77,7 @@ namespace Qtilities {
                                     \image latex property_editor_button_browser.eps "Property Browser (Button Browser Mode)" width=3in
                                     */
             };
+            Q_ENUM(BrowserType)
 
             ObjectDynamicPropertyBrowser(BrowserType browser_type = TreeBrowser, bool show_toolbar = true, Qt::ToolBarArea area = Qt::TopToolBarArea, QWidget *parent = 0);
             ~ObjectDynamicPropertyBrowser();

--- a/src/CoreGui/source/ObjectInfoTreeWidget.h
+++ b/src/CoreGui/source/ObjectInfoTreeWidget.h
@@ -61,13 +61,13 @@ namespace Qtilities {
           */
         class QTILITIES_CORE_GUI_SHARED_EXPORT qti_private_ObjectInfoTreeWidget : public QTreeWidget {
             Q_OBJECT
-            Q_ENUMS(MetaCategory)
 
         public:
             qti_private_ObjectInfoTreeWidget(QWidget *parent = 0);
             virtual ~qti_private_ObjectInfoTreeWidget();
 
             enum MetaCategory { Event, Property, Method, Dependancy, Source };
+            Q_ENUM(MetaCategory)
 
             //! Sets the QMap which contains the object references of objects to be displayed in the tree as keys and the names by which these objects are known in the script backend as values.
             virtual void setObjectMap(QMap<QPointer<QObject>, QString> object_map);

--- a/src/CoreGui/source/ObjectPropertyBrowser.h
+++ b/src/CoreGui/source/ObjectPropertyBrowser.h
@@ -54,7 +54,6 @@ namespace Qtilities {
         class QTILITIES_CORE_GUI_SHARED_EXPORT ObjectPropertyBrowser : public QWidget
         {
             Q_OBJECT
-            Q_ENUMS(BrowserType)
 
         public:
             //! This enumeration contains all the possible modes in which the property editor can be used.
@@ -72,6 +71,7 @@ namespace Qtilities {
                                     \image latex property_editor_button_browser.eps "Property Browser (Button Browser Mode)" width=3in
                                     */
             };
+            Q_ENUM(BrowserType)
 
             ObjectPropertyBrowser(BrowserType browser_type = TreeBrowser, QWidget *parent = 0);
             ~ObjectPropertyBrowser();

--- a/src/CoreGui/source/ObjectScopeWidget.h
+++ b/src/CoreGui/source/ObjectScopeWidget.h
@@ -63,7 +63,6 @@ namespace Qtilities {
         class QTILITIES_CORE_GUI_SHARED_EXPORT ObjectScopeWidget : public QWidget, public IContext {
             Q_OBJECT
             Q_DISABLE_COPY(ObjectScopeWidget)
-            Q_ENUMS(ColumnIDs)
             Q_INTERFACES(Qtilities::Core::Interfaces::IContext)
 
         public:
@@ -75,6 +74,7 @@ namespace Qtilities {
                 UsesInstanceNameColumn = 1,
                 OwnerColumn = 2
             };
+            Q_ENUM(ColumnIDs)
 
             //! When true, the object name will be shown above the object scope table.
             void setNameVisible(bool visible);

--- a/src/CoreGui/source/ObserverTreeItem.h
+++ b/src/CoreGui/source/ObserverTreeItem.h
@@ -34,7 +34,6 @@ namespace Qtilities {
         class ObserverTreeItem : public QObject
         {
             Q_OBJECT
-            Q_ENUMS(TreeItemType)
 
         public:
             //! The possible types of items which can be part of the constructed observer tree.
@@ -46,7 +45,7 @@ namespace Qtilities {
                 AllItemTypes        = TreeItem | TreeNode | CategoryItem
             };
             Q_DECLARE_FLAGS(TreeItemTypeFlags, TreeItemType)
-            Q_FLAGS(TreeItemTypeFlags)
+            Q_FLAG(TreeItemTypeFlags)
 
             ObserverTreeItem(QObject* obj = 0, ObserverTreeItem *parent = 0, const QVector<QVariant> &data = QVector<QVariant>(), TreeItemType type = InvalidType);
             ObserverTreeItem(const ObserverTreeItem& ref);

--- a/src/CoreGui/source/QtilitiesMainWindow.h
+++ b/src/CoreGui/source/QtilitiesMainWindow.h
@@ -111,7 +111,6 @@ int main(int argc, char *argv[])
         class QTILITIES_CORE_GUI_SHARED_EXPORT QtilitiesMainWindow : public QMainWindow
         {
             Q_OBJECT
-            Q_ENUMS(ModeLayout)
 
         public:
             //! The possible places where modes can be displayed.
@@ -126,7 +125,7 @@ int main(int argc, char *argv[])
                 ModesLeft = 8          /*!< Display modes as a vertical list in the left of the widget. */
             };
             Q_DECLARE_FLAGS(ModeLayoutFlags, ModeLayout)
-            Q_FLAGS(ModeLayoutFlags)
+            Q_FLAG(ModeLayoutFlags)
 
             QtilitiesMainWindow(ModeLayout modeLayout = ModesNone, QWidget * parent = 0, Qt::WindowFlags flags = 0);
             ~QtilitiesMainWindow();

--- a/src/CoreGui/source/SearchBoxWidget.h
+++ b/src/CoreGui/source/SearchBoxWidget.h
@@ -81,11 +81,6 @@ searchBoxWidget->setPlainTextEditor(myTextEdit);
           */
         class QTILITIES_CORE_GUI_SHARED_EXPORT SearchBoxWidget : public QWidget {
             Q_OBJECT
-            Q_ENUMS(WidgetMode)
-            Q_ENUMS(SearchStringChangedNotificationMode)
-            Q_ENUMS(WidgetTarget)
-            Q_ENUMS(ButtonFlag)
-            Q_ENUMS(SearchOption)
 
         public:
             //! An enumeration which is used to indicate in which mode the widget must be used.
@@ -93,17 +88,23 @@ searchBoxWidget->setPlainTextEditor(myTextEdit);
                 SearchOnly,             /*!< The widget will only show search related items. */
                 SearchAndReplace        /*!< The widget will show both show search and replace related items. */
             };
+            Q_ENUM(WidgetMode)
+
             //! An enumeration which defines when notifications about changes to the search string is emitted.
             enum SearchStringChangedNotificationMode {
                 NotifyOnChange,         /*!< Notifications will be done everytime that the search string changed. */
                 NotifyOnReturn          /*!< Notifications will be done only when the user presses return. */
             };
+            Q_ENUM(SearchStringChangedNotificationMode)
+
             //! An enumeration which is used to indicate the target on which the search and place operations must be performed.
             enum WidgetTarget {
                 ExternalTarget,         /*!< External target. Will emit needed signals for external target to connect to. This is the default. */
                 TextEdit,               /*!< Text edit set using setTextEdit(). */
                 PlainTextEdit           /*!< Plain text edit set using setPlainTextEdit(). */
             };
+            Q_ENUM(WidgetTarget)
+
             //! An enumeration which is used to indicate which buttons should be visible in the widget.
             enum ButtonFlag {
                 NoButtons = 0,              /*!< No buttons will be visible in the widget. */
@@ -115,7 +116,8 @@ searchBoxWidget->setPlainTextEditor(myTextEdit);
                 AllButtons = NextButtons | PreviousButtons | HideButtonDown | SearchOptionsButton
             };
             Q_DECLARE_FLAGS(ButtonFlags, ButtonFlag)
-            Q_FLAGS(ButtonFlags)
+            Q_ENUM(ButtonFlag)
+
             //! An enumeration which indicates which search options must be present in the widget.
             enum SearchOption {
                 NoSearchOption = 0,     /*!< Indicates that no search options must be visible. */
@@ -127,7 +129,7 @@ searchBoxWidget->setPlainTextEditor(myTextEdit);
                 AllSearchOptions = CaseSensitive | WholeWordsOnly | RegEx
             };
             Q_DECLARE_FLAGS(SearchOptions, SearchOption)
-            Q_FLAGS(SearchOptions)
+            Q_FLAG(SearchOptions)
 
             //! Constructs a search box widget using the paramaters to customize the look of the widget.
             SearchBoxWidget(SearchOptions search_options = AllSearchOptions,

--- a/src/CoreGui/source/StringListWidget.h
+++ b/src/CoreGui/source/StringListWidget.h
@@ -49,7 +49,6 @@ namespace Qtilities {
         class QTILITIES_CORE_GUI_SHARED_EXPORT StringListWidget : public QMainWindow
         {
             Q_OBJECT
-            Q_ENUMS(ListType)
 
         public:
             //! The possible types of items which are listed in the string list widget.
@@ -58,6 +57,7 @@ namespace Qtilities {
                 FilePaths            = 1, /*!< File paths. */
                 Directories          = 2  /*!< Directories. */
             };           
+            Q_ENUM(ListType)
 
             StringListWidget(const QStringList& string_list = QStringList(), Qt::ToolBarArea toolbar_area = Qt::TopToolBarArea, QWidget * parent = 0, Qt::WindowFlags flags = 0);
             ~StringListWidget();

--- a/src/CoreGui/source/TaskManagerGui.h
+++ b/src/CoreGui/source/TaskManagerGui.h
@@ -54,7 +54,8 @@ namespace Qtilities {
                                                        handled by Qtilities::Core::Task::logMessage(), the engine itself however won't have
                                                        a WidgetLoggerEngine assigned to it. Usefull in console applications. */
             };
-            Q_ENUMS(TaskLogInitialization)
+            Q_ENUM(TaskLogInitialization)
+
             //! Gets the task log initialization used by TaskManagerGui.
             /*!
               \sa setTaskLogInitializationMode

--- a/src/CoreGui/source/TaskSummaryWidget.h
+++ b/src/CoreGui/source/TaskSummaryWidget.h
@@ -78,7 +78,8 @@ task_summary_widget.findCurrentTasks();
                 DisplayOnlyBusyTasks                                = 0,  /*!< Only busy tasks and tasks which are not busy but can be started (canStart()) are shown will be displayed. */
                 DisplayAllTasks                                     = 1   /*!< All tasks registered in the global object pool will be displayed. */
             };
-            Q_ENUMS(TaskDisplayOptions)
+            Q_ENUM(TaskDisplayOptions)
+
             //! Indicates how the TaskSummaryWidget should be shown when no SingleTaskWidget items are present.
             /*!
               Default is HideSummaryWidget.
@@ -87,7 +88,8 @@ task_summary_widget.findCurrentTasks();
                 HideSummaryWidget                                   = 0,  /*!< Hide the summary widget when no tasks are present. */
                 ShowSummaryWidget                                   = 1   /*!< Show the summary widget when no tasks are present. */
             };
-            Q_ENUMS(TaskDisplayOptions)
+            Q_ENUM(TaskDisplayOptions)
+
             //! The possible ways that SingleTaskWidget widgets can be removed from the summary widget.
             /*!
               In addition to the available remove options listed, tasks will always be removed when they are deleted.
@@ -102,9 +104,8 @@ task_summary_widget.findCurrentTasks();
                 RemoveWhenStopped                                   = 8,  /*!< Remove tasks when they are stopped. */
                 RemoveDefault                                       = RemoveWhenCompletedSuccessfully
             };
-            Q_ENUMS(TaskRemoveOption)
             Q_DECLARE_FLAGS(TaskRemoveOptionFlags, TaskRemoveOption)
-            Q_FLAGS(TaskRemoveOptionFlags)
+            Q_FLAG(TaskRemoveOptionFlags)
 
             TaskSummaryWidget(TaskRemoveOption remove_options = RemoveDefault, TaskDisplayOptions display_options = DisplayOnlyBusyTasks, QWidget * parent = 0);
             ~TaskSummaryWidget();

--- a/src/CoreGui/source/TreeFileItem.h
+++ b/src/CoreGui/source/TreeFileItem.h
@@ -55,7 +55,6 @@ namespace Qtilities {
         {
             Q_OBJECT
             Q_INTERFACES(Qtilities::Core::Interfaces::IExportable)
-            Q_ENUMS(PathDisplay)
 
         public:
             //! This enumeration provides the possible ways that tree file items can be displayed.
@@ -67,6 +66,7 @@ namespace Qtilities {
                 DisplayFilePath,        /*!< Display filePath(). */
                 DisplayActualFilePath   /*!< Display actualFilePath(). */
             };
+            Q_ENUM(PathDisplay)
 
             //! Constructs a TreeFileItem object.
             /*!

--- a/src/CoreGui/source/WidgetLoggerEngine.h
+++ b/src/CoreGui/source/WidgetLoggerEngine.h
@@ -73,9 +73,8 @@ namespace Qtilities {
                 DefaultDisplays             = AllMessagesPlainTextEdit,
                 DefaultTaskDisplays         = AllMessagesPlainTextEdit | IssuesPlainTextEdit
             };
-            Q_ENUMS(MessageDisplays)
             Q_DECLARE_FLAGS(MessageDisplaysFlag, MessageDisplays)
-            Q_FLAGS(MessageDisplaysFlag)
+            Q_FLAG(MessageDisplaysFlag)
 
             //! Constructor for WidgetLoggerEngine
             /*!

--- a/src/ExtensionSystem/source/IPlugin.h
+++ b/src/ExtensionSystem/source/IPlugin.h
@@ -35,6 +35,8 @@ namespace Qtilities {
               */
             class EXTENSION_SYSTEM_SHARED_EXPORT IPlugin : virtual public IObjectBase
             {
+                Q_GADGET
+
             public:
                 IPlugin() {
                     d_state = Functional;

--- a/src/ExtensionSystem/source/IPlugin.h
+++ b/src/ExtensionSystem/source/IPlugin.h
@@ -54,7 +54,7 @@ namespace Qtilities {
                     InActive = 4                /*!< The plugin was loaded but not initialized. \sa ExtensionSystemCore::setInactivePlugins().  */
                 };
                 Q_DECLARE_FLAGS(PluginStateFlags, PluginState)
-                Q_FLAGS(PluginStateFlags)
+                Q_FLAG(PluginStateFlags)
 
                 //! Function which returns a string associated with a the plugin's state.
                 QString pluginStateString() const {

--- a/src/Logging/source/ILoggerExportable.h
+++ b/src/Logging/source/ILoggerExportable.h
@@ -25,6 +25,8 @@ namespace Qtilities {
             \brief Logger engines can implement this interface if they are able to export and reconstruct themselves.
               */
             class LOGGING_SHARED_EXPORT ILoggerExportable {
+                Q_GADGET
+
             public:
                 ILoggerExportable() {}
                 virtual ~ILoggerExportable() {}

--- a/src/Logging/source/ILoggerExportable.h
+++ b/src/Logging/source/ILoggerExportable.h
@@ -32,8 +32,8 @@ namespace Qtilities {
                 virtual ~ILoggerExportable() {}
 
                 enum ExportMode { Binary };
-                Q_DECLARE_FLAGS(ExportModeFlags, ExportMode);
-                Q_FLAGS(ExportModeFlags);
+                Q_DECLARE_FLAGS(ExportModeFlags, ExportMode)
+                Q_FLAG(ExportModeFlags)
 
                 //! Provides information about the export format(s) supported by your implementation of ILoggerExportable.
                 virtual ExportModeFlags supportedFormats() const = 0;

--- a/src/Logging/source/Logger.h
+++ b/src/Logging/source/Logger.h
@@ -80,15 +80,14 @@ namespace Qtilities {
                 AllMessageContexts      = SystemWideMessages | EngineSpecificMessages | PriorityMessages /*!< Represents all message contexts. */
             };
             Q_DECLARE_FLAGS(MessageContextFlags, MessageContext)
-            Q_FLAGS(MessageContextFlags)
-            Q_ENUMS(MessageContext)
+            Q_FLAG(MessageContextFlags)
 
             //! Indication used to indicate if an engine was added or removed to/from the logger.
             enum EngineChangeIndication {
                 EngineAdded,        /*!< Engine was added to the logger. */
                 EngineRemoved       /*!< Engine was removed from the logger. */
             };
-            Q_ENUMS(EngineChangeIndication)
+            Q_ENUM(EngineChangeIndication)
 
             //! The possible message types supported by the logger.
             /*!
@@ -105,8 +104,7 @@ namespace Qtilities {
                 AllLogLevels    = Info | Warning | Error | Fatal | Debug | Trace /*!< Represents all message types. */
             };
             Q_DECLARE_FLAGS(MessageTypeFlags, MessageType)
-            Q_FLAGS(MessageTypeFlags)
-            Q_ENUMS(MessageType)
+            Q_FLAG(MessageTypeFlags)
 
         private:
             Logger(QObject* parent = 0);

--- a/src/ProjectManagement/source/ProjectManager.h
+++ b/src/ProjectManagement/source/ProjectManager.h
@@ -49,7 +49,6 @@ namespace Qtilities {
         class PROJECT_MANAGEMENT_SHARED_EXPORT ProjectManager : public QObject, public IModificationNotifier, public ITaskContainer
         {
             Q_OBJECT
-            Q_ENUMS(ModifiedProjectsHandlingPolicy)
             Q_INTERFACES(Qtilities::Core::Interfaces::IModificationNotifier)
 
         public:
@@ -59,6 +58,8 @@ namespace Qtilities {
                 TaskOpenProject   = 1,  /*!< Open project task with progress information for openProject(). Enabled by deafult. */
                 TaskCloseProject   = 2  /*!< Close project task with progress information for closeProject(). Enabled by deafult. */
             };
+            Q_ENUM(ContainedTasks)
+
             //! ContainedTasks to string conversion function.
             QString taskNameToString(ContainedTasks task_name) const {
                 if (task_name == TaskSaveProject)
@@ -75,6 +76,7 @@ namespace Qtilities {
                 ExecNormal   = 0,       /*!< Normal operation, prompt user when feedback or input action is required. */
                 ExecSilent   = 1        /*!< Silent, do not prompt user when feedback or input action is required. Operate on defaults and if no defaults exists, fails. */
             };
+            Q_ENUM(ExecStyle)
 
             static ProjectManager* instance();
             ~ProjectManager();
@@ -87,6 +89,7 @@ namespace Qtilities {
                 PromptUser = 0,     /*!< All observer operations are available to the user (Attachment, Detachement etc.). */
                 AutoSave   = 1      /*!< The observer is read only to the user. */
             };
+            Q_ENUM(ModifiedProjectsHandlingPolicy)
 
             // ---------------------------------------
             // Functions related to project types


### PR DESCRIPTION
The plural versions (i.e. `Q_ENUMS` and `Q_FLAGS`) are now deprecated.  [This article](https://woboq.com/blog/q_enum.html) details the benefits of `Q_ENUM` and `Q_FLAG` (singular).

**However, if you merge this PR then Qtilities will no longer support anything older than Qt 5.5.**