### PR TITLE
Fix #108

### DIFF
--- a/doc/sources/Action_Management.html
+++ b/doc/sources/Action_Management.html
@@ -249,7 +249,7 @@ For more details on registering actions, see the Qtilities::CoreGui::Interfaces:
 
 \subsubsection actions_and_shortcuts_defined_actions Defined Actions
 
-The Qtilities::CoreGui::Actions namespace contains a set of ready to use action and action container Command IDs. Using the defined set of Command IDs makes it is easy to place new actions before or after them when adding actions to your menus. For more information see Qtilities::CoreGui::ActionContainer::addAction() and Qtilities::CoreGui::ActionContainer::addSeperator().
+The Qtilities::CoreGui::Actions namespace contains a set of ready to use action and action container Command IDs. Using the defined set of Command IDs makes it is easy to place new actions before or after them when adding actions to your menus. For more information see Qtilities::CoreGui::ActionContainer::addAction() and Qtilities::CoreGui::ActionContainer::addSeparator().
 
 \subsubsection actions_and_shortcuts_configurations Shortcut Configurations
 

--- a/doc/sources/The_Basics.html
+++ b/doc/sources/The_Basics.html
@@ -208,7 +208,7 @@ int main(int argc, char *argv[])
     Command* command = ACTION_MANAGER->registerActionPlaceHolder(qti_action_FILE_SETTINGS,QObject::tr("Settings"),QKeySequence(),std_context);
     QObject::connect(command->action(),SIGNAL(triggered()),config_widget,SLOT(show()));
     file_menu->addAction(command);
-    file_menu->addSeperator();
+    file_menu->addSeparator();
     command = ACTION_MANAGER->registerActionPlaceHolder(qti_action_FILE_EXIT,QObject::tr("Exit"),QKeySequence(QKeySequence::Close),std_context);
     QObject::connect(command->action(),SIGNAL(triggered()),QCoreApplication::instance(),SLOT(quit()));
     file_menu->addAction(command);

--- a/src/Core/source/GenericProperty.cpp
+++ b/src/Core/source/GenericProperty.cpp
@@ -22,8 +22,8 @@ namespace Core {
 struct GenericPropertyData {
     GenericPropertyData() : is_modified(false),
         type(GenericProperty::TypeString),
-        list_backend_seperator("|"),
-        list_storage_seperator("|"),
+        list_backend_separator("|"),
+        list_storage_separator("|"),
         level(GenericProperty::LevelStandard),
         editable(true),
         default_editable(true),
@@ -54,8 +54,8 @@ struct GenericPropertyData {
     QString description;
     QString help_id;
     QString note;
-    QString list_backend_seperator;
-    QString list_storage_seperator;
+    QString list_backend_separator;
+    QString list_storage_separator;
     GenericProperty::PropertyLevel level;
     bool editable;
     bool default_editable;
@@ -128,8 +128,8 @@ GenericProperty::GenericProperty(const GenericProperty& ref) : QObject(ref.paren
     d->state_dependent = ref.stateDependent();
     d->context_dependent = ref.contextDependent();
     d->is_internal = ref.isInternal();
-    d->list_backend_seperator = ref.listSeperatorBackend();
-    d->list_storage_seperator = ref.listSeperatorStorage();
+    d->list_backend_separator = ref.listSeparatorBackend();
+    d->list_storage_separator = ref.listSeparatorStorage();
     setIsExportable(ref.isExportable());
 }
 
@@ -160,8 +160,8 @@ GenericProperty& GenericProperty::operator=(const GenericProperty& ref) {
     d->state_dependent = ref.stateDependent();
     d->context_dependent = ref.contextDependent();
     d->is_internal = ref.isInternal();
-    d->list_backend_seperator = ref.listSeperatorBackend();
-    d->list_storage_seperator = ref.listSeperatorStorage();
+    d->list_backend_separator = ref.listSeparatorBackend();
+    d->list_storage_separator = ref.listSeparatorStorage();
     setIsExportable(ref.isExportable());
 
     setModificationState(true);
@@ -218,9 +218,9 @@ bool GenericProperty::operator==(const GenericProperty& ref) {
         return false;
     else if (d->is_internal != ref.isInternal())
         return false;
-    else if (d->list_backend_seperator != ref.listSeperatorBackend())
+    else if (d->list_backend_separator != ref.listSeparatorBackend())
         return false;
-    else if (d->list_storage_seperator != ref.listSeperatorStorage())
+    else if (d->list_storage_separator != ref.listSeparatorStorage())
         return false;
     else if (isExportable() != ref.isExportable())
         return false;
@@ -369,8 +369,8 @@ bool GenericProperty::setValueString(const QString &value, QString *errorMsg) {
             d->value = value;
             set = true;
         } else if (d->type == TypeFileList || d->type == TypePathList) {
-            // Split using the known backend seperator and set using setFileList in order to remove duplicates.
-            setFileList(value.split(d->list_backend_seperator));
+            // Split using the known backend separator and set using setFileList in order to remove duplicates.
+            setFileList(value.split(d->list_backend_separator));
             set = true;
         } else if (d->type == TypeString || d->type == TypeVariant) {
             d->value = value;
@@ -396,7 +396,7 @@ bool GenericProperty::setValueFromProperty(GenericProperty *property) {
     if (!property)
         return false;
 
-    setValueString(property->valueString().split(property->listSeperatorBackend()).join(listSeperatorBackend()));
+    setValueString(property->valueString().split(property->listSeparatorBackend()).join(listSeparatorBackend()));
     return true;
 }
 
@@ -404,8 +404,8 @@ bool GenericProperty::compareValue(GenericProperty *property) {
     if (!property)
         return false;
 
-    QStringList string_list_base = d->value.split(listSeperatorBackend());
-    QStringList string_list_ref = property->valueString().split(property->listSeperatorBackend());
+    QStringList string_list_base = d->value.split(listSeparatorBackend());
+    QStringList string_list_ref = property->valueString().split(property->listSeparatorBackend());
 
     return (string_list_base == string_list_ref);
 }
@@ -609,26 +609,42 @@ bool GenericProperty::matchesDefault() const {
 }
 
 QString GenericProperty::listSeperatorBackend() const {
-    return d->list_backend_seperator;
+    return listSeparatorBackend();
 }
 
-void GenericProperty::setListSeperatorBackend(const QString &sep) {
-    if (d->list_backend_seperator != sep) {
-        // Convert the value from the old seperator to the new seperator:
+QString GenericProperty::listSeparatorBackend() const {
+    return d->list_backend_separator;
+}
+
+void GenericProperty::setListSeperatorBackend(const QString& sep) {
+    setListSeparatorBackend(sep);
+}
+
+void GenericProperty::setListSeparatorBackend(const QString &sep) {
+    if (d->list_backend_separator != sep) {
+        // Convert the value from the old separator to the new separator:
         if (!d->value.isEmpty())
-            d->value = d->value.split(d->list_backend_seperator,QString::SkipEmptyParts).join(sep);
+            d->value = d->value.split(d->list_backend_separator,QString::SkipEmptyParts).join(sep);
         if (!d->default_value.isEmpty())
-            d->default_value = d->default_value.split(d->list_backend_seperator,QString::SkipEmptyParts).join(sep);
-        d->list_backend_seperator = sep;
+            d->default_value = d->default_value.split(d->list_backend_separator,QString::SkipEmptyParts).join(sep);
+        d->list_backend_separator = sep;
     }
 }
 
 QString GenericProperty::listSeperatorStorage() const {
-    return d->list_storage_seperator;
+    return listSeparatorStorage();
+}
+
+QString GenericProperty::listSeparatorStorage() const {
+    return d->list_storage_separator;
 }
 
 void GenericProperty::setListSeperatorStorage(const QString &sep) {
-    d->list_storage_seperator = sep;
+    setListSeparatorBackend(sep);
+}
+
+void GenericProperty::setListSeparatorStorage(const QString &sep) {
+    d->list_storage_separator = sep;
 }
 
 // --------------------------------
@@ -847,7 +863,7 @@ void GenericProperty::setFileList(const QStringList &list) {
             clean_list << FileUtils::toNativeSeparators(QDir::cleanPath(path));
         clean_list.removeDuplicates();
         clean_list.sort();
-        d->value = clean_list.join(d->list_backend_seperator);
+        d->value = clean_list.join(d->list_backend_separator);
         emit valueChanged(this);
     }
 }
@@ -881,7 +897,7 @@ void GenericProperty::setPath(const QString &file_name) {
 
 QStringList GenericProperty::fileList() const {
     if (type() == TypeFileList|| type() == TypePathList)
-        return valueString().split(d->list_backend_seperator,QString::SkipEmptyParts);
+        return valueString().split(d->list_backend_separator,QString::SkipEmptyParts);
     Q_ASSERT(type() == TypeFileList || type() == TypePathList);
     return QStringList();
 }
@@ -944,12 +960,12 @@ QString GenericProperty::mapDisplayedEnumToCommandLineEnum(QString displayed_enu
 //    QStringList csv_list;
 //    csv_list << objectName();
 //    csv_list << propertyTypeToString(d->type);
-//    csv_list << d->list_backend_seperator;
+//    csv_list << d->list_backend_separator;
 //    csv_list << listToStorageFormat(d->value);
 //    csv_list << listToStorageFormat(d->default_value);
 //    csv_list << d->description;
 //    csv_list << propertyLevelToString(d->level);
-//    csv_list << d->category.toString(d->list_storage_seperator);
+//    csv_list << d->category.toString(d->list_storage_separator);
 
 //    if (d->editable)
 //        csv_list << "1";
@@ -961,7 +977,7 @@ QString GenericProperty::mapDisplayedEnumToCommandLineEnum(QString displayed_enu
 //    csv_list << QString::number(d->int_max);
 //    csv_list << QString::number(d->int_min);
 //    csv_list << QString::number(d->int_step);
-//    csv_list << d->enum_possible_values_displayed.join(d->list_storage_seperator);
+//    csv_list << d->enum_possible_values_displayed.join(d->list_storage_separator);
 //    Command line values missing here.
 //    csv_list << d->string_reg_exp.pattern();
 //    csv_list << QString::number((int) d->string_reg_exp.patternSyntax());
@@ -991,14 +1007,14 @@ bool GenericProperty::fromCsvString(const QString &csv_string) {
     if (csv_list.count() < 2)
         return false;
 
-    QStringList aliases = csv_list[1].split(d->list_storage_seperator);
+    QStringList aliases = csv_list[1].split(d->list_storage_separator);
     foreach (const QString& alias, aliases) {
         QStringList alias_split = alias.split("::");
         if (alias_split.count() == 2) {
             PropertyAlias property_alias;
             property_alias.d_environment = alias_split.front();
 
-            // Check if the name starts with a -:             
+            // Check if the name starts with a -:
             QString name = alias_split.last();
             if (name.startsWith("-")) {
                 property_alias.d_name = name.remove(0,1);
@@ -1019,9 +1035,9 @@ bool GenericProperty::fromCsvString(const QString &csv_string) {
     if (csv_list.count() < 4)
         return false;
 
-    d->list_backend_seperator = csv_list[3].simplified();
-    if (d->list_backend_seperator.isEmpty())
-        d->list_backend_seperator = d->list_storage_seperator;
+    d->list_backend_separator = csv_list[3].simplified();
+    if (d->list_backend_separator.isEmpty())
+        d->list_backend_separator = d->list_storage_separator;
 
     if (csv_list.count() < 5)
         return false;
@@ -1039,7 +1055,7 @@ bool GenericProperty::fromCsvString(const QString &csv_string) {
     if (csv_list.count() < 7)
         return false;
 
-    d->category = QtilitiesCategory(csv_list[6],d->list_storage_seperator);
+    d->category = QtilitiesCategory(csv_list[6],d->list_storage_separator);
 
     if (csv_list.count() < 8)
         return false;
@@ -1087,12 +1103,12 @@ bool GenericProperty::fromCsvString(const QString &csv_string) {
     if (csv_list.count() < 15)
         return false;
 
-    d->enum_possible_values_displayed = csv_list[14].split(d->list_storage_seperator,QString::SkipEmptyParts);
+    d->enum_possible_values_displayed = csv_list[14].split(d->list_storage_separator,QString::SkipEmptyParts);
 
     if (csv_list.count() < 16)
         return false;
 
-    d->enum_possible_values_command_line = csv_list[15].split(d->list_storage_seperator,QString::SkipEmptyParts);
+    d->enum_possible_values_command_line = csv_list[15].split(d->list_storage_separator,QString::SkipEmptyParts);
     if (d->enum_possible_values_command_line.isEmpty())
         d->enum_possible_values_command_line = d->enum_possible_values_displayed;
     Q_ASSERT(d->enum_possible_values_command_line.count() == d->enum_possible_values_displayed.count());
@@ -1178,9 +1194,9 @@ Qtilities::Core::Interfaces::IExportable::ExportResultFlags GenericProperty::exp
     shared_properties << param_1;
 
     if (d->type & TypeListBased) {
-        SharedProperty param_2("seperatorStorage",d->list_storage_seperator);
+        SharedProperty param_2("separatorStorage",d->list_storage_separator);
         shared_properties << param_2;
-        SharedProperty param_3("seperatorBackend",d->list_backend_seperator);
+        SharedProperty param_3("separatorBackend",d->list_backend_separator);
         shared_properties << param_3;
     }
 
@@ -1229,14 +1245,23 @@ Qtilities::Core::Interfaces::IExportable::ExportResultFlags GenericProperty::imp
         setPropertyName(element_1.text());
         has_name = true;
     }
-    QDomElement element_2 = object_node->firstChildElement("seperatorStorage");
-    if (!element_2.isNull())
-        d->list_storage_seperator = element_2.text();
-    QDomElement element_3 = object_node->firstChildElement("seperatorBackend");
-    if (!element_3.isNull())
-        d->list_backend_seperator = element_3.text();
+    QDomElement element_2 = object_node->firstChildElement("separatorStorage");
+    if (element_2.isNull())
+      element_2 = object_node->firstChildElement("seperatorStorage");
+    // backwards compatibility with the "seperator" typo
 
-    // Note: Do the value only after the seperators have been restored:
+    if (!element_2.isNull())
+        d->list_storage_separator = element_2.text();
+
+    QDomElement element_3 = object_node->firstChildElement("separatorBackend");
+    if (element_3.isNull())
+        element_3 = object_node->firstChildElement("seperatorBackend");
+    // backwards compatibility with the "seperator" typo
+
+    if (!element_3.isNull())
+        d->list_backend_separator = element_3.text();
+
+    // Note: Do the value only after the separators have been restored:
     QDomElement element_4 = object_node->firstChildElement("value");
     if (!element_4.isNull()) {
         d->value = listToBackendFormat(element_4.text());
@@ -1312,21 +1337,21 @@ void GenericProperty::setModificationState(bool new_state, IModificationNotifier
 }
 
 QString GenericProperty::listToBackendFormat(const QString &value) const {
-    if (d->list_storage_seperator.isEmpty() || d->list_backend_seperator.isEmpty())
+    if (d->list_storage_separator.isEmpty() || d->list_backend_separator.isEmpty())
         return value;
-    else if (d->list_storage_seperator == d->list_backend_seperator)
+    else if (d->list_storage_separator == d->list_backend_separator)
         return value;
     else
-        return value.split(d->list_storage_seperator,QString::SkipEmptyParts).join(d->list_backend_seperator);
+        return value.split(d->list_storage_separator,QString::SkipEmptyParts).join(d->list_backend_separator);
 }
 
 QString GenericProperty::listToStorageFormat(const QString &value) const {
-    if (d->list_storage_seperator.isEmpty() || d->list_backend_seperator.isEmpty())
+    if (d->list_storage_separator.isEmpty() || d->list_backend_separator.isEmpty())
         return value;
-    else if (d->list_storage_seperator == d->list_backend_seperator)
+    else if (d->list_storage_separator == d->list_backend_separator)
         return value;
     else
-        return value.split(d->list_backend_seperator,QString::SkipEmptyParts).join(d->list_storage_seperator);
+        return value.split(d->list_backend_separator,QString::SkipEmptyParts).join(d->list_storage_separator);
 }
 
 }

--- a/src/Core/source/GenericProperty.h
+++ b/src/Core/source/GenericProperty.h
@@ -269,7 +269,7 @@ namespace Qtilities {
 
             //! Gets the value string of the property.
             /*!
-              \note If the value is a list, it is always seperated usign listBasedSeperator().
+              \note If the value is a list, it is always separated usign listBasedSeparator().
               \note When a boolean value, case insensitive variantions of "true" and "false" are used for both set and get sides.
               */
             QString valueString() const;
@@ -288,7 +288,7 @@ namespace Qtilities {
             bool compareValue(GenericProperty* property);
             //! Gets the QVariant value of the property, in the correct type.
             /*!
-              \note If the value is a list, it is always seperated usign listBasedSeperator().
+              \note If the value is a list, it is always seperated usign listBasedSeparator().
               */
             QVariant value() const;
             //! Sets the QVariant value of the property.
@@ -397,14 +397,21 @@ namespace Qtilities {
 
             //! Checks if the property matches its default value.
             bool matchesDefault() const;
-            //! Gets the backend list seperator of this property.
-            QString listSeperatorBackend() const;
-            //! Sets the backend list seperator of this property.
-            void setListSeperatorBackend(const QString& sep);
-            //! Gets the storage list seperator of this property.
-            QString listSeperatorStorage() const;
-            //! Sets the backend list seperator of this property.
-            void setListSeperatorStorage(const QString& sep);
+            //! Gets the backend list separator of this property.
+            QString listSeparatorBackend() const;
+            Q_DECL_DEPRECATED QString listSeperatorBackend() const;
+
+            //! Sets the backend list separator of this property.
+            void setListSeparatorBackend(const QString& sep);
+            Q_DECL_DEPRECATED void setListSeperatorBackend(const QString& sep);
+
+            //! Gets the storage list separator of this property.
+            QString listSeparatorStorage() const;
+            Q_DECL_DEPRECATED QString listSeperatorStorage() const;
+
+            //! Sets the backend list separator of this property.
+            void setListSeparatorStorage(const QString& sep);
+            Q_DECL_DEPRECATED void setListSeperatorStorage(const QString& sep);
 
             // --------------------------------
             // Macro Related
@@ -500,7 +507,7 @@ namespace Qtilities {
             int intValue() const;
             void setDoubleValue(double value);
             double doubleValue() const;
-            //! The value will be joined using the backend storage seperator which is , by default.
+            //! The value will be joined using the backend storage separator which is , by default.
             void setFileList(const QStringList& list);
             //! Adds files to the current files in this property if it is of type TypeFileList.
             void addFiles(const QStringList& list);
@@ -514,11 +521,11 @@ namespace Qtilities {
             QString path() const;
             //! Sets the path of this property if it is of type TypePath.
             void setPath(const QString& file_name);
-            //! The value will be split using the backend storage seperator which is , by default.
+            //! The value will be split using the backend storage separator which is , by default.
             QStringList fileList() const;
             //! Returns the file list string in the format specified, only for properties of type TypeFileList.
             QString fileListString(FileListStringFormat format = FileListStringFormat_0) const;
-            //! The value will be split using the backend storage seperator which is , by default.
+            //! The value will be split using the backend storage separator which is , by default.
             QStringList pathList() const;
             //! Returns the file list string in the format specified, only for properties of type TypePathList.
             QString pathListString(FileListStringFormat format = FileListStringFormat_0) const;
@@ -556,10 +563,10 @@ namespace Qtilities {
             The position in the list below represents the column in which information is expected:
             - Name
             - Type
-            - List based seperator in backend process.
-            - Default Value - List based values seperated by d->list_storage_seperator
+            - List based separator in backend process.
+            - Default Value - List based values seperated by d->list_storage_separator
             - Level
-            - Category - Multiple levels seperated by d->list_storage_seperator
+            - Category - Multiple levels seperated by d->list_storage_separator
             - Default Editable
             - Default Visible
             - Switch Name
@@ -567,7 +574,7 @@ namespace Qtilities {
             - Int Max
             - Int Min
             - Int Step
-            - Enum Possible Values = Seperated by d->list_storage_seperator
+            - Enum Possible Values = Seperated by d->list_storage_separator
             - String RegExp Pattern
             - String RegExp Pattern Syntax (true of false)
             - String RegExp Case Sensitive: (int) QRegExp::PatternSyntax.

--- a/src/Core/source/GenericPropertyManager.cpp
+++ b/src/Core/source/GenericPropertyManager.cpp
@@ -419,7 +419,7 @@ IExportable::ExportResultFlags GenericPropertyManager::loadNewPropertiesFile(con
                 if (new_prop->valueString() != reference_prop->valueString()) {
                     QString errorMsg;
                     QString old_value = new_prop->valueString();
-                    if (new_prop->setValueString(reference_prop->valueString().split(reference_prop->listSeperatorBackend()).join(new_prop->listSeperatorBackend()),&errorMsg))
+                    if (new_prop->setValueString(reference_prop->valueString().split(reference_prop->listSeparatorBackend()).join(new_prop->listSeparatorBackend()),&errorMsg))
                         LOG_TASK_INFO(QString("Successfully matched and updated property \"%1\" with new value \"%2\" (old value \"%3\").").arg(reference_prop->propertyName()).arg(reference_prop->valueString()).arg(old_value),task_ref);
                     else
                         LOG_TASK_WARNING(QString("Successfully matched property \"%1\" with new value \"%2\", however updating the property value failed with error: %3").arg(reference_prop->propertyName()).arg(reference_prop->valueString()).arg(errorMsg),task_ref);

--- a/src/Core/source/QtilitiesCategory.cpp
+++ b/src/Core/source/QtilitiesCategory.cpp
@@ -83,8 +83,8 @@ Qtilities::Core::QtilitiesCategory::QtilitiesCategory(const QString& category_le
     //d_category_icon = 0;
 }
 
-Qtilities::Core::QtilitiesCategory::QtilitiesCategory(const QString& category_levels, const QString& seperator) : IExportable() {
-    QStringList category_name_list = category_levels.split(seperator,QString::SkipEmptyParts);
+Qtilities::Core::QtilitiesCategory::QtilitiesCategory(const QString& category_levels, const QString& separator) : IExportable() {
+    QStringList category_name_list = category_levels.split(separator,QString::SkipEmptyParts);
     foreach(QString level,category_name_list) {
         if (level.trimmed().length() > 0)
             addLevel(level);

--- a/src/Core/source/QtilitiesCategory.h
+++ b/src/Core/source/QtilitiesCategory.h
@@ -162,10 +162,10 @@ sure that categories are handled the same way everywhere. Some usages in %Qtilit
             QtilitiesCategory(const QString& category_level_name = QString());
             //! Constructs a QtilitiesCategory object.
             /*!
-              \param category_levels A QString containing a list of categories seperated by the \p seperator parameter.
-              \param seperator The seperator string used to split the \p category_levels parameter.
+              \param category_levels A QString containing a list of categories seperated by the \p separator parameter.
+              \param separator The separator string used to split the \p category_levels parameter.
               */
-            QtilitiesCategory(const QString& category_levels, const QString& seperator);
+            QtilitiesCategory(const QString& category_levels, const QString& separator);
             //! Creates a QtilitiesCategory object from a QStringList.
             QtilitiesCategory(const QStringList& category_name_list);
             QtilitiesCategory(QDataStream &ds, Qtilities::ExportVersion version) : IObjectBase(), IExportable() {

--- a/src/Core/source/VersionInformation.cpp
+++ b/src/Core/source/VersionInformation.cpp
@@ -59,14 +59,14 @@ Qtilities::Core::VersionNumber::VersionNumber(int major, int minor, int revision
     d->development_stage_identifier = defaultDevelopmentStageIdentifer(d->development_stage);
 }
 
-Qtilities::Core::VersionNumber::VersionNumber(const QString& version, const QString& seperator, DevelopmentStage development_stage, const QString& stage_identifier) {
+Qtilities::Core::VersionNumber::VersionNumber(const QString& version, const QString& separator, DevelopmentStage development_stage, const QString& stage_identifier) {
     d = new VersionNumberPrivateData;
     d->development_stage = development_stage;
     if (stage_identifier.isEmpty())
         d->development_stage_identifier = defaultDevelopmentStageIdentifer(d->development_stage);
     else
         d->development_stage_identifier = stage_identifier;
-    fromString(version,seperator,d->development_stage_identifier,d->development_stage);
+    fromString(version,separator,d->development_stage_identifier,d->development_stage);
 }
 
 Qtilities::Core::VersionNumber::VersionNumber(const VersionNumber& ref)  {
@@ -321,22 +321,22 @@ void Qtilities::Core::VersionNumber::setVersionDevelopmentStage(int version) {
     d->version_development_stage = version;
 }
 
-QString Qtilities::Core::VersionNumber::toString(const QString& seperator) const {
+QString Qtilities::Core::VersionNumber::toString(const QString& separator) const {
     QString version;
     if (d->is_version_minor_used && d->is_version_revision_used) {
         if (d->field_width_minor == -1 && d->field_width_revision == -1)
-            version = QString::number(d->version_major) + seperator + QString("%1").arg(d->version_minor) + seperator + QString("%1").arg(d->version_revision);
+            version = QString::number(d->version_major) + separator + QString("%1").arg(d->version_minor) + separator + QString("%1").arg(d->version_revision);
         else if (d->field_width_minor == -1 && !(d->field_width_revision == -1))
-            version = QString::number(d->version_major) + seperator + QString("%1").arg(d->version_minor) + seperator + QString("%1").arg(d->version_revision,d->field_width_revision,10,QChar('0'));
+            version = QString::number(d->version_major) + separator + QString("%1").arg(d->version_minor) + separator + QString("%1").arg(d->version_revision,d->field_width_revision,10,QChar('0'));
         else if (d->field_width_minor != -1 && d->field_width_revision == -1)
-            version = QString::number(d->version_major) + seperator + QString("%1").arg(d->version_minor,d->field_width_minor,10,QChar('0')) + seperator + QString("%1").arg(d->version_revision);
+            version = QString::number(d->version_major) + separator + QString("%1").arg(d->version_minor,d->field_width_minor,10,QChar('0')) + separator + QString("%1").arg(d->version_revision);
         else if (d->field_width_minor != -1 && d->field_width_revision != -1)
-            version = QString::number(d->version_major) + seperator + QString("%1").arg(d->version_minor,d->field_width_minor,10,QChar('0')) + seperator + QString("%1").arg(d->version_revision,d->field_width_revision,10,QChar('0'));
+            version = QString::number(d->version_major) + separator + QString("%1").arg(d->version_minor,d->field_width_minor,10,QChar('0')) + separator + QString("%1").arg(d->version_revision,d->field_width_revision,10,QChar('0'));
     } else if (d->is_version_minor_used && !d->is_version_revision_used) {
         if (d->field_width_minor == -1)
-            version = QString::number(d->version_major) + seperator + QString("%1").arg(d->version_minor);
+            version = QString::number(d->version_major) + separator + QString("%1").arg(d->version_minor);
         else if (d->field_width_minor != -1)
-            version = QString::number(d->version_major) + seperator + QString("%1").arg(d->version_minor,d->field_width_minor,10,QChar('0'));
+            version = QString::number(d->version_major) + separator + QString("%1").arg(d->version_minor,d->field_width_minor,10,QChar('0'));
     } else if (!d->is_version_minor_used && !d->is_version_revision_used)
         version = QString::number(d->version_major);
 
@@ -348,11 +348,11 @@ QString Qtilities::Core::VersionNumber::toString(const QString& seperator) const
     return version;
 }
 
-void Qtilities::Core::VersionNumber::fromString(const QString& version, const QString& seperator, const QString& stage_identifier, DevelopmentStage stage) {
+void Qtilities::Core::VersionNumber::fromString(const QString& version, const QString& separator, const QString& stage_identifier, DevelopmentStage stage) {
     QString cleaned_version = version.toLower();
     cleaned_version.replace(" ","");
 
-    QStringList list = cleaned_version.split(seperator,QString::SkipEmptyParts);
+    QStringList list = cleaned_version.split(separator,QString::SkipEmptyParts);
     if (list.isEmpty())
         return;
 
@@ -465,8 +465,8 @@ bool Qtilities::Core::VersionInformation::isSupportedVersion(const VersionNumber
     return d->supported_versions.contains(version_number);
 }
 
-bool Qtilities::Core::VersionInformation::isSupportedVersion(const QString& version_string, const QString& seperator) const {
-    VersionNumber version_number(version_string,seperator);
+bool Qtilities::Core::VersionInformation::isSupportedVersion(const QString& version_string, const QString& separator) const {
+    VersionNumber version_number(version_string,separator);
     return d->supported_versions.contains(version_number);
 }
 

--- a/src/Core/source/VersionInformation.h
+++ b/src/Core/source/VersionInformation.h
@@ -133,7 +133,7 @@ example2_from_string.setIsVersionRevisionUsed(false);
              * \param revision The revision number.
              */
             VersionNumber(int major, int minor = 0, int revision = 0, int stage_version = 0, DevelopmentStage development_stage = DevelopmentStageNone);
-            VersionNumber(const QString& version, const QString& seperator = ".", DevelopmentStage develoment_stage = DevelopmentStageNone, const QString& stage_identifier = QString());
+            VersionNumber(const QString& version, const QString& separator = ".", DevelopmentStage develoment_stage = DevelopmentStageNone, const QString& stage_identifier = QString());
             VersionNumber(const VersionNumber& ref);
             virtual ~VersionNumber();
 
@@ -242,17 +242,17 @@ example2_from_string.setIsVersionRevisionUsed(false);
 
             //! Returns a string represenation of the complete VersionNumber, thus the major, minor and revision parts of the version.
             /*!
-              \param seperator By default this is a point, thus ".". In some cases it is desirable to use a custom field seperator. For example as an underscore "_" can be desirable when the version information must be appended to a file name.
+              \param separator By default this is a point, thus ".". In some cases it is desirable to use a custom field separator. For example as an underscore "_" can be desirable when the version information must be appended to a file name.
               */
-            virtual QString toString(const QString& seperator = ".") const;
+            virtual QString toString(const QString& separator = ".") const;
             //! Gets the version information from a string represenation, thus the major, minor and revision parts of the version.
             /*!
               \param version The version string.
-              \param seperator By default this is a point, thus ".". In some cases it is desirable to use a custom field seperator. For example as an underscore "_" can be desirable when the version information must be appended to a file name.
+              \param separator By default this is a point, thus ".". In some cases it is desirable to use a custom field separator. For example as an underscore "_" can be desirable when the version information must be appended to a file name.
 
               This function keeps the used parts of the version, thus it does not change that.
               */
-            virtual void fromString(const QString& version, const QString& seperator = ".", const QString& stage_identifier = QString(), DevelopmentStage stage_type = DevelopmentStageNone);
+            virtual void fromString(const QString& version, const QString& separator = ".", const QString& stage_identifier = QString(), DevelopmentStage stage_type = DevelopmentStageNone);
 
         private:
             VersionNumberPrivateData* d;
@@ -311,7 +311,7 @@ version_info << VersionNumber(2,0,0);
             /*!
               This function will construct a VersionNumber object from the string and check if it is supported.
               */
-            bool isSupportedVersion(const QString& version_string, const QString& seperator = ".") const;
+            bool isSupportedVersion(const QString& version_string, const QString& separator = ".") const;
             //! Returns a QStringList with the string representations of all supported versions.
             QStringList supportedVersionString() const;
             //! Overload << operator so more supported versions can be streamed easily.

--- a/src/CoreGui/source/ActionContainer.h
+++ b/src/CoreGui/source/ActionContainer.h
@@ -42,11 +42,14 @@ namespace Qtilities {
               \param before Inserts the action before the action represented by before.
               */
             virtual void addAction(Command *action, const QString &before = QString()) = 0;
-            //! Adds a seperator to the action container. If the action container is a menu bar, this call does nothing.
+            //! Adds a separator to the action container. If the action container is a menu bar, this call does nothing.
             /*!
-              \param before Inserts the seperator before the action represented by before.
+              \param before Inserts the separator before the action represented by before.
+              \deprecated Use \ref addSeparator instead, that one's spelled properly.
               */
-            virtual void addSeperator(const QString &before = QString()) = 0;
+            Q_DECL_DEPRECATED virtual void addSeperator(const QString &before = QString()) = 0;
+
+            virtual void addSeparator(const QString &before = QString()) { addSeperator(before); }
 
             //! The menu bar associated with this action container. If the action container is a menu bar, 0 is returned.
             virtual QMenuBar *menuBar() const = 0;
@@ -82,7 +85,7 @@ namespace Qtilities {
             // --------------------------------
             QMenu *menu() const;
             void addAction(Command *command, const QString &before = QString());
-            void addSeperator(const QString &before = QString());
+            Q_DECL_DEPRECATED void addSeperator(const QString &before = QString());
             QMenuBar *menuBar() const;
             void addMenu(ActionContainer *menu, const QString &before = QString());
 

--- a/src/CoreGui/source/GenericPropertyPathEditor.cpp
+++ b/src/CoreGui/source/GenericPropertyPathEditor.cpp
@@ -31,7 +31,7 @@ GenericPropertyPathEditor::GenericPropertyPathEditor(GenericProperty::PropertyTy
     ui->setupUi(this);
     d_default_open_path = QtilitiesApplication::applicationSessionPath();
     d_property_type = property_type;
-    d_list_seperator_backend = "|";
+    d_list_separator_backend = "|";
     d_editable = true;
 
     if (d_property_type == GenericProperty::TypeFile || d_property_type == GenericProperty::TypePath)
@@ -64,7 +64,11 @@ void GenericPropertyPathEditor::setPropertyName(const QString &name) {
 }
 
 void GenericPropertyPathEditor::setListSeperatorBackend(const QString &list_seperator) {
-    d_list_seperator_backend = list_seperator;
+    setListSeparatorBackend(list_seperator);
+}
+
+void GenericPropertyPathEditor::setListSeparatorBackend(const QString &list_separator) {
+    d_list_separator_backend = list_separator;
 }
 
 void GenericPropertyPathEditor::setDefaultOpenPath(const QString &default_open_path) {
@@ -73,7 +77,7 @@ void GenericPropertyPathEditor::setDefaultOpenPath(const QString &default_open_p
 
 void GenericPropertyPathEditor::setCurrentValues(const QStringList &current_values) {
     d_current_values = current_values;
-    setText(d_current_values.join(d_list_seperator_backend));
+    setText(d_current_values.join(d_list_separator_backend));
 }
 
 void GenericPropertyPathEditor::on_btnBrowse_clicked() {
@@ -107,7 +111,7 @@ void GenericPropertyPathEditor::on_btnBrowse_clicked() {
             dialog.setWindowTitle(d_property_name);
 
         if (dialog.exec()) {
-            ui->txtEditor->setText(string_list_widget->stringList().join(d_list_seperator_backend));
+            ui->txtEditor->setText(string_list_widget->stringList().join(d_list_separator_backend));
         }
     } else if (d_property_type == GenericProperty::TypePathList) {
         StringListWidget* string_list_widget = new StringListWidget;
@@ -124,13 +128,13 @@ void GenericPropertyPathEditor::on_btnBrowse_clicked() {
             dialog.setWindowTitle(d_property_name);
 
         if (dialog.exec()) {
-            ui->txtEditor->setText(string_list_widget->stringList().join(d_list_seperator_backend));
+            ui->txtEditor->setText(string_list_widget->stringList().join(d_list_separator_backend));
         }
     }
 }
 
 void GenericPropertyPathEditor::handleValueChanged(const QString &value) {
-    d_current_values = value.split(d_list_seperator_backend,QString::SkipEmptyParts);
+    d_current_values = value.split(d_list_separator_backend,QString::SkipEmptyParts);
     emit valueChanged(value);
 }
 

--- a/src/CoreGui/source/GenericPropertyPathEditor.h
+++ b/src/CoreGui/source/GenericPropertyPathEditor.h
@@ -38,7 +38,8 @@ namespace Qtilities {
             void setItemFilter(const QString& file_filter);
             void setEditable(bool editable);
             void setPropertyName(const QString& name);
-            void setListSeperatorBackend(const QString& list_seperator);
+            Q_DECL_DEPRECATED void setListSeperatorBackend(const QString& list_seperator);
+            void setListSeparatorBackend(const QString& list_separator);
             void setDefaultOpenPath(const QString& default_open_path);
             void setCurrentValues(const QStringList& current_values);
 
@@ -54,7 +55,7 @@ namespace Qtilities {
             QString d_file_filter;
             QString d_default_open_path;
             GenericProperty::PropertyType d_property_type;
-            QString d_list_seperator_backend;
+            QString d_list_separator_backend;
             QStringList d_current_values;
             bool d_editable;
             QString d_property_name;

--- a/src/CoreGui/source/GenericPropertyTypeManagers.cpp
+++ b/src/CoreGui/source/GenericPropertyTypeManagers.cpp
@@ -72,10 +72,14 @@ bool PathPropertyManager::editable(QtProperty *property) const {
 }
 
 QString PathPropertyManager::listSeperatorBackend(QtProperty *property) const {
+    return listSeparatorBackend(property);
+}
+
+QString PathPropertyManager::listSeparatorBackend(QtProperty *property) const {
     if (propertyToData.contains(property)) {
         QPointer<GenericProperty> generic_property = propertyToData[property];
         if (generic_property)
-            return generic_property->listSeperatorBackend();
+            return generic_property->listSeparatorBackend();
     }
     return "|";
 }
@@ -178,7 +182,7 @@ QWidget *FileEditorFactory::createEditor(PathPropertyManager *manager, QtPropert
         editor->setText(manager->value(property));
     else if (manager->propertyType(property) == GenericProperty::TypeFileList || manager->propertyType(property) == GenericProperty::TypePathList) {
         editor->setCurrentValues(manager->listValues(property));
-        editor->setListSeperatorBackend(manager->listSeperatorBackend(property));
+        editor->setListSeparatorBackend(manager->listSeparatorBackend(property));
     }
 
     connect(editor,SIGNAL(valueChanged(QString)),SLOT(slotSetValue(QString)));

--- a/src/CoreGui/source/GenericPropertyTypeManagers.h
+++ b/src/CoreGui/source/GenericPropertyTypeManagers.h
@@ -49,7 +49,8 @@ namespace Qtilities {
             QString propertyName(QtProperty* property) const;
             bool contextDependent(QtProperty* property) const;
             bool editable(QtProperty* property) const;
-            QString listSeperatorBackend(QtProperty* property) const;
+            QString listSeparatorBackend(QtProperty* property) const;
+            Q_DECL_DEPRECATED QString listSeperatorBackend(QtProperty* property) const;
             //! Returns the current list values of the property. Only applicable to FileList and PathList properties.
             QStringList listValues(QtProperty* property) const;
             GenericProperty::PropertyType propertyType(QtProperty* property) const;

--- a/src/CoreGui/source/ObserverWidget.cpp
+++ b/src/CoreGui/source/ObserverWidget.cpp
@@ -123,7 +123,7 @@ struct Qtilities::CoreGui::ObserverWidgetData {
         actionFilterNodes(0),
         actionFilterItems(0),
         actionFilterCategories(0),
-        actionFilterTypeSeperator(0),
+        actionFilterTypeSeparator(0),
         last_display_flags(ObserverHints::NoDisplayFlagsHint),
         current_column_visibility(ObserverHints::ColumnNoHints),
         column_visibility_initialized(false),
@@ -270,7 +270,7 @@ struct Qtilities::CoreGui::ObserverWidgetData {
     QAction* actionFilterNodes;
     QAction* actionFilterItems;
     QAction* actionFilterCategories;
-    QAction* actionFilterTypeSeperator;
+    QAction* actionFilterTypeSeparator;
 
     //! This hint keeps track of the previously used activeHints()->displayFlagsHint(). If it changed, the toolbars will be reconstructed in the refreshActionToolBar() function.
     ObserverHints::DisplayFlags last_display_flags;
@@ -1956,7 +1956,7 @@ void Qtilities::CoreGui::ObserverWidget::refreshActions() {
             d->actionFilterCategories->setVisible(false);
             d->actionFilterNodes->setVisible(false);
             d->actionFilterItems->setVisible(false);
-            d->actionFilterTypeSeperator->setVisible(false);
+            d->actionFilterTypeSeparator->setVisible(false);
         }
         // Remove & Delete All Actions
         if (d->selection_parent_observer_context) {
@@ -1987,7 +1987,7 @@ void Qtilities::CoreGui::ObserverWidget::refreshActions() {
             d->actionFilterCategories->setVisible(true);
             d->actionFilterNodes->setVisible(true);
             d->actionFilterItems->setVisible(true);
-            d->actionFilterTypeSeperator->setVisible(true);
+            d->actionFilterTypeSeparator->setVisible(true);
         }
     }
 
@@ -3244,7 +3244,7 @@ void Qtilities::CoreGui::ObserverWidget::toggleSearchBox() {
 
         QMenu* search_options_menu = d->searchBoxWidget->searchOptionsMenu();
         if (search_options_menu) {
-            d->actionFilterTypeSeperator = search_options_menu->addSeparator();
+            d->actionFilterTypeSeparator = search_options_menu->addSeparator();
             d->actionFilterNodes = new QAction(tr("Filter Nodes"),this);
             d->actionFilterNodes->setCheckable(true);
             connect(d->actionFilterNodes,SIGNAL(triggered()),SLOT(handleSearchItemTypesChanged()));
@@ -3261,7 +3261,7 @@ void Qtilities::CoreGui::ObserverWidget::toggleSearchBox() {
                 d->actionFilterCategories->setVisible(false);
                 d->actionFilterNodes->setVisible(false);
                 d->actionFilterItems->setVisible(false);
-                d->actionFilterTypeSeperator->setVisible(false);
+                d->actionFilterTypeSeparator->setVisible(false);
             }
 
             setSearchBoxCheckedItemFilters(d->search_item_filter_flags);

--- a/src/Examples/ClipboardExample/main.cpp
+++ b/src/Examples/ClipboardExample/main.cpp
@@ -81,7 +81,7 @@ int main(int argc, char *argv[])
 
     QObject::connect(command->action(),SIGNAL(triggered()),config_widget,SLOT(show()));
     edit_menu->addAction(command);
-    edit_menu->addSeperator();
+    edit_menu->addSeparator();
     // Register action placeholders for the copy, cut and paste actions:
     command = ACTION_MANAGER->registerActionPlaceHolder(qti_action_EDIT_COPY,QObject::tr("Copy"),QKeySequence(QKeySequence::Copy));
     command->setCategory(QtilitiesCategory("Editing"));

--- a/src/Examples/MainWindowExample/main.cpp
+++ b/src/Examples/MainWindowExample/main.cpp
@@ -121,7 +121,7 @@ int main(int argc, char *argv[])
     command = ACTION_MANAGER->registerActionPlaceHolder(qti_action_EDIT_REDO,QObject::tr("Redo"),QKeySequence(QKeySequence::Redo));
     command->setCategory(QtilitiesCategory("Editing"));
     edit_menu->addAction(command);
-    edit_menu->addSeperator();
+    edit_menu->addSeparator();
     command = ACTION_MANAGER->registerActionPlaceHolder(qti_action_EDIT_COPY,QObject::tr("Copy"),QKeySequence(QKeySequence::Copy));
     command->setCategory(QtilitiesCategory("Editing"));
     edit_menu->addAction(command);
@@ -131,14 +131,14 @@ int main(int argc, char *argv[])
     command = ACTION_MANAGER->command(qti_action_EDIT_PASTE);
     command->setCategory(QtilitiesCategory("Editing"));
     edit_menu->addAction(command);
-    edit_menu->addSeperator();
+    edit_menu->addSeparator();
     command = ACTION_MANAGER->registerActionPlaceHolder(qti_action_EDIT_SELECT_ALL,QObject::tr("Select All"),QKeySequence(QKeySequence::SelectAll));
     command->setCategory(QtilitiesCategory("Editing"));
     edit_menu->addAction(command);
     command = ACTION_MANAGER->registerActionPlaceHolder(qti_action_EDIT_CLEAR,QObject::tr("Clear"));
     command->setCategory(QtilitiesCategory("Editing"));
     edit_menu->addAction(command);
-    edit_menu->addSeperator();
+    edit_menu->addSeparator();
     command = ACTION_MANAGER->registerActionPlaceHolder(qti_action_EDIT_FIND,QObject::tr("Find"),QKeySequence(QKeySequence::Find));
     edit_menu->addAction(command);
 
@@ -148,13 +148,13 @@ int main(int argc, char *argv[])
 
     // Create the Example before plugin loading since it registers a project items:
     ExampleMode* example_mode = new ExampleMode;
-    file_menu->addSeperator();
+    file_menu->addSeparator();
     command = ACTION_MANAGER->registerActionPlaceHolder("File.ToggleModeIcon",QObject::tr("Toggle Mode Icon"),QKeySequence(),std_context);
     QObject::connect(command->action(),SIGNAL(triggered()),example_mode,SLOT(toggleModeIcon()));
     file_menu->addAction(command);
     OBJECT_MANAGER->registerObject(example_mode);
 
-    file_menu->addSeperator();
+    file_menu->addSeparator();
     command = ACTION_MANAGER->registerActionPlaceHolder(qti_action_FILE_EXIT,QObject::tr("Exit"),QKeySequence(QKeySequence::Close),std_context);
     QObject::connect(command->action(),SIGNAL(triggered()),QCoreApplication::instance(),SLOT(quit()));
     file_menu->addAction(command);

--- a/src/Examples/ObjectManagement/ObjectManagementModeWidget.cpp
+++ b/src/Examples/ObjectManagement/ObjectManagementModeWidget.cpp
@@ -104,7 +104,7 @@ Qtilities::Examples::ObjectManagement::ObjectManagementModeWidget::ObjectManagem
     Command* command = ACTION_MANAGER->registerAction("Example.PopulateObserver",d->actionAddExampleObjects,context);
     command->setCategory(QtilitiesCategory(QApplication::applicationName()));
     file_menu->addAction(command,qti_action_FILE_EXIT);
-    file_menu->addSeperator(qti_action_FILE_EXIT);
+    file_menu->addSeparator(qti_action_FILE_EXIT);
 
     d->dot_file_action = new QAction("Create Dot Graph",this);
     connect(d->dot_file_action,SIGNAL(triggered()),SLOT(createDotFile()));
@@ -130,7 +130,7 @@ Qtilities::Examples::ObjectManagement::ObjectManagementModeWidget::ObjectManagem
     command->setCategory(QtilitiesCategory(QApplication::applicationName()));
     file_menu->addAction(command,qti_action_FILE_EXIT);
 
-    file_menu->addSeperator(qti_action_FILE_EXIT);
+    file_menu->addSeparator(qti_action_FILE_EXIT);
 
     // ---------------------------
     // Initialize widget control toolbar and actions

--- a/src/Examples/ObjectManagement/main.cpp
+++ b/src/Examples/ObjectManagement/main.cpp
@@ -89,7 +89,7 @@ int main(int argc, char *argv[])
     QObject::connect(command->action(),SIGNAL(triggered()),&config_widget,SLOT(show()));
     QtilitiesApplication::setConfigWidget(&config_widget);
     file_menu->addAction(command);
-    file_menu->addSeperator();
+    file_menu->addSeparator();
     command = ACTION_MANAGER->registerActionPlaceHolder(qti_action_FILE_EXIT,QObject::tr("Exit"),QKeySequence(QKeySequence::Close),std_context);
     QObject::connect(command->action(),SIGNAL(triggered()),QCoreApplication::instance(),SLOT(quit()));
     file_menu->addAction(command);
@@ -101,7 +101,7 @@ int main(int argc, char *argv[])
     command = ACTION_MANAGER->registerActionPlaceHolder(qti_action_EDIT_REDO,QObject::tr("Redo"),QKeySequence(QKeySequence::Redo));
     command->setCategory(QtilitiesCategory("Editing"));
     edit_menu->addAction(command);
-    edit_menu->addSeperator();
+    edit_menu->addSeparator();
     command = ACTION_MANAGER->registerActionPlaceHolder(qti_action_EDIT_COPY,QObject::tr("Copy"),QKeySequence(QKeySequence::Copy));
     command->setCategory(QtilitiesCategory("Editing"));
     edit_menu->addAction(command);
@@ -111,14 +111,14 @@ int main(int argc, char *argv[])
     command = ACTION_MANAGER->registerActionPlaceHolder(qti_action_EDIT_PASTE,QObject::tr("Paste"),QKeySequence(QKeySequence::Paste));
     command->setCategory(QtilitiesCategory("Editing"));
     edit_menu->addAction(command);
-    edit_menu->addSeperator();
+    edit_menu->addSeparator();
     command = ACTION_MANAGER->registerActionPlaceHolder(qti_action_EDIT_SELECT_ALL,QObject::tr("Select All"),QKeySequence(QKeySequence::SelectAll));
     command->setCategory(QtilitiesCategory("Editing"));
     edit_menu->addAction(command);
     command = ACTION_MANAGER->registerActionPlaceHolder(qti_action_EDIT_CLEAR,QObject::tr("Clear"));
     command->setCategory(QtilitiesCategory("Editing"));
     edit_menu->addAction(command);
-    edit_menu->addSeperator();
+    edit_menu->addSeparator();
     command = ACTION_MANAGER->registerActionPlaceHolder(qti_action_EDIT_FIND,QObject::tr("Find"),QKeySequence(QKeySequence::Find));
     edit_menu->addAction(command);
 

--- a/src/Examples/TasksExample/main.cpp
+++ b/src/Examples/TasksExample/main.cpp
@@ -91,7 +91,7 @@ int main(int argc, char *argv[])
     Command* command = ACTION_MANAGER->registerActionPlaceHolder(qti_action_FILE_SETTINGS,QObject::tr("Settings"),QKeySequence(),std_context);
     QObject::connect(command->action(),SIGNAL(triggered()),&config_widget,SLOT(show()));
     file_menu->addAction(command);
-    file_menu->addSeperator();
+    file_menu->addSeparator();
     command = ACTION_MANAGER->registerActionPlaceHolder(qti_action_FILE_EXIT,QObject::tr("Exit"),QKeySequence(QKeySequence::Close),std_context);
     QObject::connect(command->action(),SIGNAL(triggered()),QCoreApplication::instance(),SLOT(quit()));
     file_menu->addAction(command);

--- a/src/Examples/TclScriptingExample/main.cpp
+++ b/src/Examples/TclScriptingExample/main.cpp
@@ -110,7 +110,7 @@ int main(int argc, char ** argv) {
     Command* command = ACTION_MANAGER->registerActionPlaceHolder(qti_action_FILE_SETTINGS,QObject::tr("Settings"),QKeySequence(),std_context);
     QObject::connect(command->action(),SIGNAL(triggered()),&config_widget,SLOT(show()));
     file_menu->addAction(command);
-    file_menu->addSeperator();
+    file_menu->addSeparator();
     command = ACTION_MANAGER->registerActionPlaceHolder(qti_action_FILE_EXIT,QObject::tr("Exit"),QKeySequence(QKeySequence::Close),std_context);
     QObject::connect(command->action(),SIGNAL(triggered()),QCoreApplication::instance(),SLOT(quit()));
     file_menu->addAction(command);

--- a/src/Examples/TheBasicsExample/main.cpp
+++ b/src/Examples/TheBasicsExample/main.cpp
@@ -73,7 +73,7 @@ int main(int argc, char *argv[])
     Command* command = ACTION_MANAGER->registerActionPlaceHolder(qti_action_FILE_SETTINGS,QObject::tr("Settings"),QKeySequence(),std_context);
     QObject::connect(command->action(),SIGNAL(triggered()),config_widget,SLOT(show()));
     file_menu->addAction(command);
-    file_menu->addSeperator();
+    file_menu->addSeparator();
     command = ACTION_MANAGER->registerActionPlaceHolder(qti_action_FILE_EXIT,QObject::tr("Exit"),QKeySequence(QKeySequence::Close),std_context);
     QObject::connect(command->action(),SIGNAL(triggered()),QCoreApplication::instance(),SLOT(quit()));
     file_menu->addAction(command);

--- a/src/Plugins/ProjectManagementPlugin/source/ProjectManagementPlugin.cpp
+++ b/src/Plugins/ProjectManagementPlugin/source/ProjectManagementPlugin.cpp
@@ -102,7 +102,7 @@ bool Qtilities::Plugins::ProjectManagement::ProjectManagementPlugin::initialize(
         Command* command = ACTION_MANAGER->command(qti_action_PROJECTS_SAVE_AS);
         file_menu->addAction(command,PROJECT_MANAGER->projectMenuItemsBeforeCommand());
     }
-    file_menu->addSeperator(PROJECT_MANAGER->projectMenuItemsBeforeCommand());
+    file_menu->addSeparator(PROJECT_MANAGER->projectMenuItemsBeforeCommand());
     // ---------------------------
     // Recent Projects Menu
     // ---------------------------


### PR DESCRIPTION
- Replace all spelling errors of "separator"
- Mark the old versions as Q_DECL_DEPRECATED
- Make GenericProperty write "separator", but still accept "seperator"
